### PR TITLE
Fix raw/proc dir creation from `brainsets config`

### DIFF
--- a/brainsets/cli.py
+++ b/brainsets/cli.py
@@ -109,13 +109,17 @@ def config(raw, processed):
                 "Enter processed data directory",
                 type=click.Path(file_okay=False, dir_okay=True),
             )
+    
+    raw = Path(os.path.expanduser(raw))
+    processed = Path(os.path.expanduser(processed))
 
-    os.makedirs(raw, exist_ok=True)
-    os.makedirs(processed, exist_ok=True)
+    # Create directories
+    raw.mkdir(parents=True, exist_ok=True)
+    processed.mkdir(parents=True, exist_ok=True)
 
-    # Convert to absolute paths
-    raw = os.path.abspath(raw)
-    processed = os.path.abspath(processed)
+    # Save config
+    raw = str(raw)
+    processed = str(processed)
 
     config = load_config()
     config["raw_dir"] = raw

--- a/brainsets/cli.py
+++ b/brainsets/cli.py
@@ -109,7 +109,7 @@ def config(raw, processed):
                 "Enter processed data directory",
                 type=click.Path(file_okay=False, dir_okay=True),
             )
-    
+
     raw = Path(os.path.expanduser(raw))
     processed = Path(os.path.expanduser(processed))
 


### PR DESCRIPTION
When doing `brainsets config`, if I use `~/test/raw` and `~/test/processed` as the 2 directories, the script incorrectly creates the directories `./~/test/raw` and `./~/test/processed`. 
Note that this bug surfaces only if the directories are entered through the prompts.

This PR fixes the problem.