### PR TITLE
Per-dataset environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ data/raw
 # macOS system files
 .DS_Store
 **/.DS_Store
+
+uv.lock

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/Snakefile
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/Snakefile
@@ -8,13 +8,15 @@ DANDI_ID = "000140"
 RAW_DIR = config["RAW_DIR"]
 PROCESSED_DIR = config["PROCESSED_DIR"]
 
+EXTRA_REQS = "dandi==0.61.2"
+
 checkpoint pei_pandarinath_nlb_2021_download_data:
     output:
         f"{RAW_DIR}/{DATASET}/manifest.txt"
     shell:
         f"""
         mkdir -p {RAW_DIR}/{DATASET}
-        dandi download -o {RAW_DIR}/{DATASET} -e refresh DANDI:000140/0.220113.0408
+        uv run --with {EXTRA_REQS} --active dandi download -o {RAW_DIR}/{DATASET} -e refresh DANDI:000140/0.220113.0408
         find {RAW_DIR}/{DATASET}/ -type f -name "*.nwb" | sed "s|^{RAW_DIR}/{DATASET}/||" | sed "s|^/*||" > {{output}}
         """
 

--- a/brainsets_pipelines/perich_miller_population_2018/Snakefile
+++ b/brainsets_pipelines/perich_miller_population_2018/Snakefile
@@ -8,6 +8,8 @@ DANDI_ID = "000688"
 RAW_DIR = config["RAW_DIR"]
 PROCESSED_DIR = config["PROCESSED_DIR"]
 
+EXTRA_REQS = "dandi==0.61.2"
+
 
 checkpoint perich_miller_population_2018_download_data:
     output:
@@ -15,7 +17,7 @@ checkpoint perich_miller_population_2018_download_data:
     shell:
         f"""
         mkdir -p {RAW_DIR}/{DATASET}
-        dandi download -o {RAW_DIR}/{DATASET} -e refresh DANDI:000688/draft
+        uv run --with {EXTRA_REQS} --active dandi download -o {RAW_DIR}/{DATASET} -e refresh DANDI:000688/draft
         find {RAW_DIR}/{DATASET}/ -type f -name "*.nwb" | sed "s|^{RAW_DIR}/{DATASET}/||" | sed "s|^/*||" > {{output}}
         """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pydantic~=2.0",
     "pulp==2.7.0",
     "click~=8.1.3",
-    "dandi==0.61.2",
+    "uv",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**Problem**: Each dataset needs its own environment on top of the base `brainsets` environment. Our current solution is to install different environments for each dataset manually.

**This PR**: Introduces the idea of using `uv run --with <extra requirements> [command]` to create automatically create isolated environments for each dataset.  The extra packages needed for each dataset will be defined in the `Snakefile` and the creators of these `Snakefiles` are expected to add them.

Currently implemented only for the two datasets we have in the main branch. 

- Removed `dandi` as a requirement of `brainsets` and added `uv`.