### PR TITLE
added new attributes to brainsetdescriptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: 24.3.0
     hooks:
     - id: black
-      language_version: python3.9
+      language_version: python3

--- a/brainsets/descriptions.py
+++ b/brainsets/descriptions.py
@@ -25,10 +25,15 @@ class BrainsetDescription(temporaldata.Data):
         Original data source (usually a URL, or a short description otherwise)
     description : str
         Text description of the brainset
+    publication_list : list[str]
+        List of references to publication associated with the dataset
+    subject_list : list[str]
+        List of subjects in the dataset
     brainsets_version : str, optional
         Version of brainsets package used, defaults to current version
     temporaldata_version : str, optional
         Version of temporaldata package used, defaults to current version
+
     """
 
     id: str
@@ -36,6 +41,8 @@ class BrainsetDescription(temporaldata.Data):
     derived_version: str
     source: str
     description: str
+    publication_list: list[str]
+    subject_list: list[str]
     brainsets_version: str = brainsets.__version__
     temporaldata_version: str = temporaldata.__version__
 

--- a/brainsets_pipelines/perich_miller_population_2018/prepare_data.py
+++ b/brainsets_pipelines/perich_miller_population_2018/prepare_data.py
@@ -159,6 +159,13 @@ def main():
         "contains spiking activity—manually spike sorted in three subjects, and "
         "threshold crossings in the fourth subject—obtained from up to 192 electrodes "
         "per session, cursor position and velocity, and other task related metadata.",
+        publication_list=[
+            "Perich MG, Gallego JA, Miller LE. A Neural Population Mechanism for Rapid Learning. Neuron. 2018 Nov 21;100(4):964-976.e7. doi: 10.1016/j.neuron.2018.09.030. Epub 2018 Oct 18. PMID: 30344047; PMCID: PMC6250582.",
+            "Perich MG, Miller LE. Altered tuning in primary motor cortex does not account for behavioral adaptation during force field learning. Exp Brain Res. 2017 Sep;235(9):2689-2704. doi: 10.1007/s00221-017-4997-1. Epub 2017 Jun 6. PMID: 28589233; PMCID: PMC5709199.",
+            "Glaser JI, Perich MG, Ramkumar P, Miller LE, Kording KP. Population coding of conditional probability distributions in dorsal premotor cortex. Nat Commun. 2018 May 3;9(1):1788. doi: 10.1038/s41467-018-04062-6. PMID: 29725023; PMCID: PMC5934453.",
+            "Churchland MM, Cunningham JP, Kaufman MT, Foster JD, Nuyujukian P, Ryu SI, Shenoy KV. Neural population dynamics during reaching. Nature. 2012 Jul 5;487(7405):51-6. doi: 10.1038/nature11129. PMID: 22722855; PMCID: PMC3393826.",
+        ],
+        subject_list=["Mihili (M)", "Chewie (C)", "Jaco (J)", "Mr.T (T)"],
     )
 
     logging.info(f"Processing file: {args.input_file}")

--- a/tests/test_descriptions.py
+++ b/tests/test_descriptions.py
@@ -1,0 +1,36 @@
+import pytest
+from brainsets.descriptions import (
+    BrainsetDescription,
+)  # Replace `your_module` with the actual module name
+
+
+def test_brainset_description_creation():
+    brainset_description = BrainsetDescription(
+        id="data_id",
+        origin_version="dandi_id",
+        derived_version="version",
+        source="source",
+        description=(
+            "This dataset has neural activity and behavior"
+            " this is another line of description"
+        ),
+        publication_list=["Some publication reference", "another_reference"],
+        subject_list=["bob", "sue"],
+    )
+
+    # Check attributes
+    assert brainset_description.id == "data_id"
+    assert brainset_description.origin_version == "dandi_id"
+    assert brainset_description.derived_version == "version"
+    assert brainset_description.source == "source"
+    assert (
+        "This dataset has neural activity and behavior"
+        in brainset_description.description
+    )
+    assert brainset_description.publication_list == [
+        "Some publication reference",
+        "another_reference",
+    ]
+    assert brainset_description.subject_list == ["bob", "sue"]
+    assert isinstance(brainset_description.brainsets_version, str)
+    assert isinstance(brainset_description.temporaldata_version, str)


### PR DESCRIPTION
Added `publication_list` and `subject_list` to the BrainsetDescription. Will be helpful for automatically generating READMEs in future updates. Updated the perich dataset to show how this works. Also, added a test for descriptions.