### PR TITLE
Add option for extra args and propagate down to snakemake configs

### DIFF
--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -106,22 +106,6 @@ def prepare(
     click.echo(f"Raw data directory: {raw_dir}")
     click.echo(f"Processed data directory: {processed_dir}")
 
-    # Parse extra config from command line
-    extra_config = []
-    it = iter(ctx.args)
-    for token in it:
-        if token.startswith("--"):
-            key = token.lstrip("-").replace("-", "_")
-            try:
-                value = next(it)
-                if value.startswith("--"):
-                    raise StopIteration
-            except StopIteration:
-                raise click.BadParameter(f"Option {token} needs a value")
-            extra_config.append(f"{key}={value}")
-        else:
-            raise click.BadParameter(f"Unexpected extra argument: {token}")
-
     # Construct base Snakemake command with configuration
     command = [
         "snakemake",
@@ -130,7 +114,7 @@ def prepare(
         "--config",
         f"RAW_DIR={raw_dir}",
         f"PROCESSED_DIR={processed_dir}",
-        *extra_config,
+        f"EXTRA_CONFIG={' '.join(ctx.args)}",
         f"-c{cores}",
         "all",
         "--verbose" if verbose else "--quiet",


### PR DESCRIPTION
For some brainsets, there may be configurable options that change how the processing will be done. One option is to create separate brainsets for each of these configs, but it becomes infeasible and cumbersome when there are many small options that change the output, e.g. for benchmarks that have different types of splits. This PR provides the option to pass in extra arguments to `brainsets prepare` that will be propagated down to `snakemake` as configs. That way a snakefile can accept additional arguments as `config["x"]`.