### PR TITLE
Fix redirect issue while downloading files for flint_slutzky_accurate_2012

### DIFF
--- a/brainsets_pipelines/flint_slutzky_accurate_2012/Snakefile
+++ b/brainsets_pipelines/flint_slutzky_accurate_2012/Snakefile
@@ -25,6 +25,7 @@ checkpoint download_data:
             wget --load-cookies {RAW_DIR}/{DATASET}/cookies.txt -O "{RAW_DIR}/{DATASET}/Flint_2012_e3.mat" "https://portal.nersc.gov/project/crcns/download/dream/data_sets/Flint_2012?fn=dream%2Fdata_sets%2FFlint_2012%2FFlint_2012_e3.mat&username=&password=&guest=1&fn=dream%2Fdata_sets%2FFlint_2012%2FFlint_2012_e3.mat&agree_terms=on&submit=Login+Anonymously"
             wget --load-cookies {RAW_DIR}/{DATASET}/cookies.txt -O "{RAW_DIR}/{DATASET}/Flint_2012_e4.mat" "https://portal.nersc.gov/project/crcns/download/dream/data_sets/Flint_2012?fn=dream%2Fdata_sets%2FFlint_2012%2FFlint_2012_e4.mat&username=&password=&guest=1&fn=dream%2Fdata_sets%2FFlint_2012%2FFlint_2012_e4.mat&agree_terms=on&submit=Login+Anonymously"
             wget --load-cookies {RAW_DIR}/{DATASET}/cookies.txt -O "{RAW_DIR}/{DATASET}/Flint_2012_e5.mat" "https://portal.nersc.gov/project/crcns/download/dream/data_sets/Flint_2012?fn=dream%2Fdata_sets%2FFlint_2012%2FFlint_2012_e5.mat&username=&password=&guest=1&fn=dream%2Fdata_sets%2FFlint_2012%2FFlint_2012_e5.mat&agree_terms=on&submit=Login+Anonymously"
+            rm {RAW_DIR}/{DATASET}/cookies.txt
             find {RAW_DIR}/{DATASET}/ -type f -name "*.mat" | sed "s|^{RAW_DIR}/{DATASET}/||" | sed "s|^/*||" > {{output}}
         else
             echo "Failed downloading raw data. Please report this as an issue on GitHub."


### PR DESCRIPTION
This PR updates the `download_data` step of the `flint_slutzky_accurate_2012` snakemake pipeline to handle CRCNS’s new download flow. Previously, direct `wget` calls to CRCNS dataset URLs succeeded without authentication. Now, there is an auth gateway so if there is no session where terms of use were accepted, a 302 redirect is issued to a login page.
<img width="816" height="252" alt="Screenshot 2025-11-09 at 3 26 51 PM" src="https://github.com/user-attachments/assets/0a90ea39-69a4-4488-b24f-8da95fe124a9" />

Even for anonymous use, the terms must be accepted via a POST request, which returns a session cookie that must be used for subsequent file downloads. To resolve this, there is now a pre-download anonymous login. If a valid cookie (`crcns_nersc_download`) is returned, proceed to download all .mat files using `--load-cookies`. Otherwise, print an error message and terminate. I verified locally that this new pipeline successfully downloads and processes all dataset files.