### PR TITLE
Fix CI in other repositories

### DIFF
--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -205,18 +205,11 @@ def _determine_brainsets_spec() -> str:
     Determine how to install brainsets when not specified in requirements.txt.
 
     Priority:
-    1. CI environment (install from current branch)
-    2. Detect current installation source (git, local)
-    3. Default (assume downloaded from PyPI)
+    1. Detect current installation source (git, local) from package metadata
+    2. Default (assume downloaded from PyPI)
     """
 
-    # # First, check if we're in CI
-    # if os.environ.get("CI") == "true" or os.environ.get("GITHUB_ACTIONS") == "true":
-    #     repo_url = os.environ.get("GITHUB_REPOSITORY", "neuro-galaxy/brainsets")
-    #     commit_sha = os.environ.get("GITHUB_SHA")
-    #     return f"git+https://github.com/{repo_url}.git@{commit_sha}"
-
-    # Second, try to detect if brainsets was installed via a URL or local file
+    # Try to detect if brainsets was installed via a URL or local file
     url_source = _detect_brainsets_installation_url()
     if url_source:
         return url_source


### PR DESCRIPTION
Addressing #60 

Looks like the entire logic for "detecting if we're in a CI, and then using ref from that" was unnecessary. The `_detect_brainsets_installation_url()` function itself does a good job for CI environments as well.

This PR removes the special CI-handling logic.

Example of working torch_brain CI [here](https://github.com/neuro-galaxy/torch_brain/pull/151).
(had to fix other unrelated bugs in `examples/` for it to work).

**Important**: The merge order should be:
1. Merge this PR
2. Remove the `vinam/cli_fix` ref in torch_brain [#151](https://github.com/neuro-galaxy/torch_brain/pull/151)
3. Merge torch_brain #151