### PR TITLE
v0.2.0 Release Action fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,9 +56,9 @@ jobs:
         python-version: "3.10"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
-        enable-cache: true
+        version: "0.6.11"
 
     - name: Build a binary wheel and a source tarball
       run: uv build


### PR DESCRIPTION
`publish.yml` fails at "Install uv" ([failed run](https://github.com/neuro-galaxy/brainsets/actions/runs/20498785762/job/58902960220)). This PR makes the "Install uv" section similar to `testing.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publish workflow configuration with newer build tooling versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->