### PR TITLE
Add new attributes to taxonomy

### DIFF
--- a/brainsets/taxonomy/recording_tech.py
+++ b/brainsets/taxonomy/recording_tech.py
@@ -25,6 +25,7 @@ class RecordingTech(StringIntEnum):
     ECOG_ARRAY_ECOGS = 29
     MICRO_ECOG_ARRAY_ECOGS = 30
     STEREO_EEG = 31
+    SCALP_EEG = 32
 
     TWO_PHOTON_IMAGING = 40
 

--- a/brainsets/taxonomy/subject.py
+++ b/brainsets/taxonomy/subject.py
@@ -19,3 +19,17 @@ class Sex(StringIntEnum):
     MALE = M = 1
     FEMALE = F = 2
     OTHER = O = 3
+
+
+class Condition(StringIntEnum):
+    UNKNOWN = 0
+    HEALTHY_CONTROL = 1
+    AUTISM = 2
+    EPILEPSY = 3
+    DEPRESSION = 4
+    ANXIETY = 5
+    ATTENTION_DEFICIT = 6
+    COGNITIVE_DEFICIT = 7
+    DEMENTIA = 8
+    ALZHEIMERS = 9
+    PARKINSONS = 10

--- a/brainsets/taxonomy/task.py
+++ b/brainsets/taxonomy/task.py
@@ -23,6 +23,12 @@ class Task(StringIntEnum):
     # Full sentence speaking
     CONTINUOUS_SPEAKING_SENTENCE = 7
 
+    CONTINUOUS_VISUAL_CODING = 8
+    CONTINUOUS_AUDITORY_CODING = 9
+    CONTINUOUS_AUDIO_VISUAL_CODING = 10
+
+    DISCRETE_BUTTON_PRESS = 11
+
 
 class Stimulus(StringIntEnum):
     """Stimuli can variously act like inputs (for conditioning) or like outputs."""


### PR DESCRIPTION
Hi,  I added some new attributes in taxonomy:

- added `SCALP_EEG` for `RecordingTech`
- added few tasks for continuous audio/visual coding in `Task` + button press task
- for subject, I suggest a new class `Condition` (or could be diagnosis) to define common neurological, neuropsychological and neurodegenerative conditions. This could be especially useful to compare data and results across different subject populations at large scale. 

I was not sure if there is a standard numerical value attribution you are following (e.g., `SCALP_EEG = 32`) so these are merely suggestions. 