### PR TITLE
Enabling cache in the CI pipeline 

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,6 +24,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         version: "0.6.11"
+        enable-cache: true
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
Setting up the environment for testing is sometimes slow which means that the testing step can take a long time. 

[Here](https://github.com/neuro-galaxy/brainsets/actions/runs/22311819333/job/64545711476?pr=83) for example, the tests ran in 20 seconds but installing the project took ore than 15 minutes.

This PR proposes to enable uv's cache to speed up that entire process.