### PR TITLE
Fold generation to support optional stratification

### DIFF
--- a/brainsets/utils/split.py
+++ b/brainsets/utils/split.py
@@ -239,92 +239,133 @@ def _create_interval_split(intervals: Interval, indices: np.ndarray) -> Interval
     return split
 
 
-def generate_stratified_folds(
+def generate_folds(
     intervals: Interval,
-    stratify_by: str,
     n_folds: int = 5,
     val_ratio: float = 0.2,
     seed: int = 42,
+    stratify_by: Optional[str] = None,
 ) -> List[Data]:
-    """
-    Generates stratified train/valid/test splits using a two-stage splitting process.
+    """Generate train/valid/test splits using a two-stage splitting process.
+
+    If *stratify_by* is None, splitting uses KFold (outer) and ShuffleSplit (inner).
+    If *stratify_by* is an attribute name present on the intervals, splitting uses
+    StratifiedKFold and StratifiedShuffleSplit so that each fold preserves the
+    class distribution of that attribute.
 
     The splitting is performed in two stages:
-        1. Outer split (StratifiedKFold): The intervals are divided into n_folds,
-           where each fold uses one partition as the test set and the remaining
-           partitions as train+valid. Stratification ensures each fold maintains
-           the class distribution of the original data.
-        2. Inner split (StratifiedShuffleSplit): The train+valid portion of each fold
-           is further split into train and valid sets using val_ratio, while preserving
-           the class distribution.
+        1. Outer split: The intervals are divided into *n_folds*, where each fold
+           uses one partition as the test set and the remaining partitions as train+valid.
+        2. Inner split: The train+valid portion of each fold is further split into
+           train and valid sets using *val_ratio*.
+    When used, stratification ensures each fold maintains the class distribution of the
+    original data according to the *stratify_by* attribute.
 
     Args:
         intervals: The intervals to split.
         n_folds: Number of folds for cross-validation.
         val_ratio: Ratio of validation set relative to train+valid combined.
-        seed: Random seed.
-        stratify_by: The attribute name to use for stratification (e.g., "id", "label",
-            "class"). The intervals must have this attribute.
+        seed: Random seed for reproducibility.
+        stratify_by: Optional attribute name to stratify by (e.g., "id", "label").
+            If provided, intervals must have this attribute.
 
     Returns:
         List of Data objects, one for each fold.
 
     Raises:
-        ValueError: If the intervals don't have the specified stratify_by attribute.
-        ValueError: If there are fewer samples than n_folds.
+        ValueError: If there are fewer samples than *n_folds*.
+        ValueError: If stratify_by is provided but intervals do not have that attribute.
     """
+    if n_folds < 2:
+        raise ValueError(f"n_folds must be at least 2, got {n_folds}")
+    if not (0.0 < val_ratio < 1.0):
+        raise ValueError(
+            f"val_ratio must be between 0 and 1 (exclusive), got {val_ratio}"
+        )
+    if stratify_by is not None and not hasattr(intervals, stratify_by):
+        raise ValueError(
+            f"Intervals must have a '{stratify_by}' attribute for stratification."
+        )
+
     try:
-        from sklearn.model_selection import StratifiedKFold, StratifiedShuffleSplit
+        from sklearn.model_selection import (
+            KFold,
+            StratifiedKFold,
+            ShuffleSplit,
+            StratifiedShuffleSplit,
+        )
     except ImportError:
         raise ImportError(
             "This function requires the scikit-learn library which you can install with "
             "`pip install scikit-learn`"
         )
 
-    if not hasattr(intervals, stratify_by):
-        raise ValueError(
-            f"Intervals must have a '{stratify_by}' attribute for stratification."
-        )
+    use_stratify = stratify_by is not None
 
-    class_labels = getattr(intervals, stratify_by)
-    if len(class_labels) < n_folds:
-        raise ValueError(
-            f"Not enough samples ({len(class_labels)}) for {n_folds} folds."
-        )
+    if use_stratify:
+        class_labels = getattr(intervals, stratify_by)
+        if len(class_labels) < n_folds:
+            raise ValueError(
+                f"Not enough samples ({len(class_labels)}) for {n_folds} folds."
+            )
+    else:
+        if len(intervals) < n_folds:
+            raise ValueError(
+                f"Not enough samples ({len(intervals)}) for {n_folds} folds."
+            )
 
-    outer_splitter = StratifiedKFold(n_splits=n_folds, shuffle=True, random_state=seed)
     folds = []
     sample_indices = np.arange(len(intervals))
 
-    for fold_idx, (train_val_indices, test_indices) in enumerate(
-        outer_splitter.split(sample_indices, class_labels)
-    ):
-        test_split = _create_interval_split(intervals, test_indices)
-
-        train_val_labels = class_labels[train_val_indices]
-        inner_splitter = StratifiedShuffleSplit(
-            n_splits=1, test_size=val_ratio, random_state=seed + fold_idx
+    if use_stratify:
+        outer_splitter = StratifiedKFold(
+            n_splits=n_folds, shuffle=True, random_state=seed
         )
-
-        for train_indices, val_indices in inner_splitter.split(
-            train_val_indices, train_val_labels
+        for fold_idx, (train_val_indices, test_indices) in enumerate(
+            outer_splitter.split(sample_indices, class_labels)
         ):
-            train_original_indices = train_val_indices[train_indices]
-            val_original_indices = train_val_indices[val_indices]
-
-            train_split = _create_interval_split(intervals, train_original_indices)
-            val_split = _create_interval_split(intervals, val_original_indices)
-
-            combined_domain = train_split | val_split | test_split
-
-            fold_data = Data(
-                train=train_split,
-                valid=val_split,
-                test=test_split,
-                domain=combined_domain,
+            test_split = _create_interval_split(intervals, test_indices)
+            train_val_labels = class_labels[train_val_indices]
+            inner_splitter = StratifiedShuffleSplit(
+                n_splits=1, test_size=val_ratio, random_state=seed + fold_idx
             )
-
-            folds.append(fold_data)
+            for train_indices, val_indices in inner_splitter.split(
+                train_val_indices, train_val_labels
+            ):
+                train_original_indices = train_val_indices[train_indices]
+                val_original_indices = train_val_indices[val_indices]
+                train_split = _create_interval_split(intervals, train_original_indices)
+                val_split = _create_interval_split(intervals, val_original_indices)
+                combined_domain = train_split | val_split | test_split
+                fold_data = Data(
+                    train=train_split,
+                    valid=val_split,
+                    test=test_split,
+                    domain=combined_domain,
+                )
+                folds.append(fold_data)
+    else:
+        outer_splitter = KFold(n_splits=n_folds, shuffle=True, random_state=seed)
+        for fold_idx, (train_val_indices, test_indices) in enumerate(
+            outer_splitter.split(sample_indices)
+        ):
+            test_split = _create_interval_split(intervals, test_indices)
+            inner_splitter = ShuffleSplit(
+                n_splits=1, test_size=val_ratio, random_state=seed + fold_idx
+            )
+            for train_indices, val_indices in inner_splitter.split(train_val_indices):
+                train_original_indices = train_val_indices[train_indices]
+                val_original_indices = train_val_indices[val_indices]
+                train_split = _create_interval_split(intervals, train_original_indices)
+                val_split = _create_interval_split(intervals, val_original_indices)
+                combined_domain = train_split | val_split | test_split
+                fold_data = Data(
+                    train=train_split,
+                    valid=val_split,
+                    test=test_split,
+                    domain=combined_domain,
+                )
+                folds.append(fold_data)
 
     return folds
 

--- a/brainsets_pipelines/kemp_sleep_edf_2013/pipeline.py
+++ b/brainsets_pipelines/kemp_sleep_edf_2013/pipeline.py
@@ -28,7 +28,7 @@ from brainsets.descriptions import (
 from brainsets.taxonomy import RecordingTech, Species, Sex
 from brainsets.pipeline import BrainsetPipeline
 from brainsets.utils.split import (
-    generate_stratified_folds,
+    generate_folds,
     generate_string_kfold_assignment,
 )
 from brainsets.utils.s3_utils import get_cached_s3_client
@@ -362,7 +362,7 @@ def create_splits(
     if len(filtered) == 0:
         raise ValueError("No valid epochs remaining after filtering")
 
-    folds = generate_stratified_folds(
+    folds = generate_folds(
         filtered,
         stratify_by="id",
         n_folds=n_folds,

--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from temporaldata import Data, Interval
 from brainsets.utils.split import (
-    generate_stratified_folds,
+    generate_folds,
     generate_string_kfold_assignment,
 )
 
@@ -27,7 +27,7 @@ class TestGenerateStratifiedFolds:
 
         n_folds = 5
         val_ratio = 0.25
-        folds = generate_stratified_folds(
+        folds = generate_folds(
             intervals, stratify_by="id", n_folds=n_folds, val_ratio=val_ratio, seed=42
         )
 
@@ -100,7 +100,7 @@ class TestGenerateStratifiedFolds:
 
         intervals = Interval(start=start, end=end, label=labels)
 
-        folds = generate_stratified_folds(
+        folds = generate_folds(
             intervals, stratify_by="label", n_folds=5, val_ratio=0.25, seed=42
         )
 
@@ -120,7 +120,68 @@ class TestGenerateStratifiedFolds:
         intervals = Interval(start=start, end=end)
 
         with pytest.raises(ValueError, match="must have a 'label' attribute"):
-            generate_stratified_folds(intervals, stratify_by="label", n_folds=5)
+            generate_folds(intervals, stratify_by="label", n_folds=5)
+
+
+class TestGenerateNonStratifiedFolds:
+    def test_generate_non_stratified_folds(self):
+        n_samples = 100
+        start = np.arange(n_samples, dtype=float)
+        end = start + 1.0
+        intervals = Interval(start=start, end=end)
+
+        n_folds = 5
+        val_ratio = 0.25
+        folds = generate_folds(
+            intervals,
+            n_folds=n_folds,
+            val_ratio=val_ratio,
+            seed=42,
+        )
+
+        assert isinstance(folds, list)
+        assert len(folds) == n_folds
+
+        test_starts_all = []
+        for fold in folds:
+            assert isinstance(fold, Data)
+            train, valid, test = fold.train, fold.valid, fold.test
+
+            assert len(test) == 20
+            assert len(valid) == 20
+            assert len(train) == 60
+            assert len(train) + len(valid) + len(test) == n_samples
+
+            assert hasattr(fold, "domain")
+            test_starts_all.append(test.start)
+
+        all_test_starts = np.concatenate(test_starts_all)
+        all_test_starts_sorted = np.sort(all_test_starts)
+        original_starts_sorted = np.sort(intervals.start)
+        assert np.allclose(all_test_starts_sorted, original_starts_sorted)
+
+    def test_generate_folds_deterministic(self):
+        n_samples = 50
+        start = np.arange(n_samples, dtype=float)
+        end = start + 1.0
+        intervals = Interval(start=start, end=end)
+
+        folds1 = generate_folds(intervals, n_folds=5, val_ratio=0.2, seed=123)
+        folds2 = generate_folds(intervals, n_folds=5, val_ratio=0.2, seed=123)
+
+        assert len(folds1) == len(folds2)
+        for f1, f2 in zip(folds1, folds2):
+            assert np.allclose(f1.train.start, f2.train.start)
+            assert np.allclose(f1.valid.start, f2.valid.start)
+            assert np.allclose(f1.test.start, f2.test.start)
+
+    def test_generate_folds_few_samples(self):
+        start = np.arange(3, dtype=float)
+        end = start + 1.0
+        intervals = Interval(start=start, end=end)
+
+        with pytest.raises(ValueError, match="Not enough samples"):
+            generate_folds(intervals, n_folds=5, seed=42)
 
 
 class TestGenerateStringKfoldAssignment:


### PR DESCRIPTION
Adressing issue #94.
Small PR to modify the util to generate folds, making stratification optional and used when a label is provided. 
Otherwise, random K-folds are generated without stratification. 
`generate_stratified_folds` is updated as `generate_folds`, with the `stratify_by` argument used to differentiate logics.

- Tests are updated for both use cases. 
- Kemp_sleep_edf_2013 is updated to use the new util. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fold generation now supports optional stratification, enabling both stratified and non-stratified splitting modes based on user preference.
  * Added validation for fold count, validation ratio, and attribute presence to catch configuration errors.

* **API Changes**
  * Fold generation function renamed with updated parameter signature; stratification is now optional rather than required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->