### PR TITLE
docs: lead with BrainsetPipeline and add end-to-end example

### DIFF
--- a/docs/source/concepts/prepare_data.rst
+++ b/docs/source/concepts/prepare_data.rst
@@ -51,16 +51,16 @@ extract metadata, and package it into a :obj:`temporaldata.Data` object.
 .. code-block:: python
 
     def process(self, fpath):
-        # 1. Load data from the provided path
-        # 2. Extract metadata and neural variables
-        # 3. Create data object
+        # 1. Load, extract, and create your data object
         data = Data(...)
 
-        # 4. Split data into train, validation and test
+        # 2. Split data into train, validation and test
         data.set_train_domain(...)
         
-        # Note: The pipeline handles saving automatically!
-        return data
+        # 3. Save manually to the directory provided by the pipeline
+        save_path = self.processed_dir / f"{self.brainset_id}.h5"
+        with h5py.File(save_path, "w") as file:
+            data.to_hdf5(file, serialize_fn_map=serialize_fn_map)
 
 
 
@@ -283,6 +283,9 @@ Add all the metadata and data objects to a :obj:`temporaldata.Data` object:
 
 Split the data into train, validation and test sets, you can do this in any way that makes sense for your dataset.
 
+.. note::
+   The ``set_train_domain()``, ``set_valid_domain()``, and ``set_test_domain()`` methods are provided by the :obj:`temporaldata.Data` class.
+
 .. tab:: Split by Trials
 
     .. code-block:: python
@@ -317,6 +320,7 @@ Split the data into train, validation and test sets, you can do this in any way 
         data.set_train_domain(train_interval)
         data.set_valid_domain(valid_interval)
         data.set_test_domain(test_interval)
+    
 
 Tips
 ----


### PR DESCRIPTION
This PR(#104) addresses issue #102 by restructuring the prepare_data documentation.

Key changes:

- Introduced the BrainsetPipeline class at the start to give immediate context for the workflow.
- Renumbered existing steps to follow the new Pipeline-first structure.
- Added a full end-to-end example at the end to demonstrate a complete, runnable script.

These updates improve the guide’s flow, helping new users understand the pipeline container before diving into implementation details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new pipeline-definition and full end-to-end example sections to the data-prep docs.
  * Simplified the template to emphasize implementing a single processing step; pipeline handles saving.
  * Added a detailed workflow covering dataset descriptions, neural and behavioral data extraction, assembly into temporal data, splits, and tips/cross-references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->