### PR TITLE
Make RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 the default if not specified

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI commands in brainsets._cli module."""
 
+import os
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -41,6 +42,7 @@ class TestPrepareCommand:
             mock_subprocess.assert_called_once()
             call_args = mock_subprocess.call_args
             command = call_args[1].get("command") or call_args[0][0]
+            env = call_args[1].get("env")
 
             assert command[0] == "uv"
             assert command[1] == "run"
@@ -49,19 +51,27 @@ class TestPrepareCommand:
             assert "brainsets_pipelines" in command[3]
             assert command[4] == "--isolated"
             assert command[5] == "--no-project"
-            assert command[6] == "--python"
-            assert command[7] == "3.11"
-            assert command[8] == "--with-editable"
-            assert ("brainsets" in command[9]) and ("file://" in command[9])
-            assert command[10] == "--with"
-            assert command[11] == "dandi==0.71.3"
-            assert command[12] == "python"
-            assert command[13] == "-m"
-            assert command[14] == "brainsets.runner"
-            assert "pipeline.py" in command[15]
+            assert "--python" in command
+            assert command[command.index("--python") + 1] == "3.11"
+
+            if "--with-editable" in command:
+                editable_spec = command[command.index("--with-editable") + 1]
+                assert ("brainsets" in editable_spec) and ("file://" in editable_spec)
+
+            assert "--with" in command
+            with_spec = command[command.index("--with") + 1]
+            assert "dandi==0.71.3" in with_spec
+            assert ("brainsets" in with_spec) or ("--with-editable" in command)
+
+            assert "python" in command
+            assert "-m" in command
+            assert "brainsets.runner" in command
+            assert any("pipeline.py" in arg for arg in command)
             assert f"--raw-dir={mock_config['raw_dir']}" in command
             assert f"--processed-dir={mock_config['processed_dir']}" in command
             assert "-c4" in command  # default cores
+            assert env is not None
+            assert env["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] == "0"
 
     def test_cli_raw_processed_dirs_override(self, tmp_path):
         """Test prepare command with raw and processed dirs overridden."""
@@ -118,3 +128,19 @@ class TestPrepareCommand:
 
             assert "--unknown" in command[-2]
             assert "option" in command[-1]
+
+    def test_prepare_respects_user_ray_uv_setting(self, mock_config):
+        """Test prepare command does not override user's Ray uv runtime setting."""
+        runner = CliRunner()
+
+        with (
+            patch.dict(os.environ, {"RAY_ENABLE_UV_RUN_RUNTIME_ENV": "1"}, clear=False),
+            patch("brainsets._cli.cli_prepare.load_config", return_value=mock_config),
+            patch("brainsets._cli.cli_prepare.subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0)
+            result = runner.invoke(cli, ["prepare", "pei_pandarinath_nlb_2021"])
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+
+            call_args = mock_subprocess.call_args
+            assert call_args[1].get("env") is None


### PR DESCRIPTION
For some prepare pipelines (e.g. neuroprobe), large python packages are needed to be downloaded via uv (e.g. torch). Newly spawned workers would re-download by default, which causes timeout for the workers. A much more efficient route would be to download to a single uv runtime env and have all workers share that. This is what this fix proposes. 

Edit: This only appears necessary if the number of available cores on the machine is equal to -c cores provided to brainsets prepare. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved subprocess environment variable handling to conditionally disable runtime propagation when using inline metadata, while respecting any user-configured settings.

* **Tests**
  * Added comprehensive tests for environment variable management, including validation that subprocess calls respect user preferences and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->