### PR TITLE
Add `config show` and `config set` subcommands; default dataset `root` to config

### DIFF
--- a/.github/workflows/pipeline_testing.yml
+++ b/.github/workflows/pipeline_testing.yml
@@ -31,34 +31,34 @@ jobs:
 
     - name: Download pei_pandarinath_nlb_2021
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare pei_pandarinath_nlb_2021
 
     - name: Download perich_miller_population_2018
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare perich_miller_population_2018 -s c_20131219_center_out_reaching
 
     - name: Download allen_visual_coding_ophys_2016
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare allen_visual_coding_ophys_2016 -s 717913184
 
     - name: Download churchland_shenoy_neural_2012
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare churchland_shenoy_neural_2012 -s jenkins_20090912
 
     - name: Download flint_slutzky_accurate_2012
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare flint_slutzky_accurate_2012 -s flint_2012_e1
 
     - name: Download kemp_sleep_edf_2013
       if: matrix.python-version != '3.9'
       # scikit-learn>=1.7.2 is not compatible with python3.9
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare kemp_sleep_edf_2013 -s sleep_cassette_SC4002E0-PSG
 
     - name: Download vollan_moser_alternating_2025 (navigation)

--- a/.github/workflows/pipeline_testing.yml
+++ b/.github/workflows/pipeline_testing.yml
@@ -63,11 +63,11 @@ jobs:
 
     - name: Download vollan_moser_alternating_2025 (navigation)
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare vollan_moser_alternating_2025 -s of_24365_2
 
     - name: Download vollan_moser_alternating_2025 (sleep)
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare vollan_moser_alternating_2025 -s sleep_25691_1
 

--- a/.github/workflows/pipeline_testing_matrix.yml
+++ b/.github/workflows/pipeline_testing_matrix.yml
@@ -35,5 +35,5 @@ jobs:
 
     - name: Download pei_pandarinath_nlb_2021
       run: |
-        uv run brainsets config --raw-dir data/raw --processed-dir data/processed
+        uv run brainsets config set --raw-dir data/raw --processed-dir data/processed
         uv run brainsets prepare pei_pandarinath_nlb_2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- Added `config show`/`config set` subcommands and default dataset `root` to configured `processed_dir` ([#122](https://github.com/neuro-galaxy/brainsets/pull/122)).
 - Added normalization schemes for sex, age, and species in `SubjectDescription` ([#78](https://github.com/neuro-galaxy/brainsets/pull/78)).
 - Added generic data extraction helpers in `mne_utils` to handle MNE Raw objects ([#78](https://github.com/neuro-galaxy/brainsets/pull/78)).
 - Enriched `s3_utils` with additional functionalities to get data from public buckets ([#78](https://github.com/neuro-galaxy/brainsets/pull/78)).

--- a/README.md
+++ b/README.md
@@ -45,17 +45,22 @@ This work is only made possible thanks to the public release of these valuable d
 ### Configuring data directories
 First, configure the directories where brainsets will store raw and processed data:
 ```bash
-brainsets config
+brainsets config set
 ```
 
 You will be prompted to enter the paths to the raw and processed data directories.
 ```bash
-$> brainsets config
+$> brainsets config set
 Enter raw data directory: ./data/raw
 Enter processed data directory: ./data/processed
 ```
 
-You can update the configuration at any time by running the `config` command again.
+You can update the configuration at any time by running the `config set` command again.
+
+To view the current configuration:
+```bash
+brainsets config show
+```
 
 ### Listing available datasets
 You can list the available datasets by running the `list` command:

--- a/brainsets/_cli/cli_config.py
+++ b/brainsets/_cli/cli_config.py
@@ -33,10 +33,10 @@ def config(ctx, raw_dir, processed_dir):
             "deprecated. Use `brainsets config set` instead.",
             err=True,
         )
-        ctx.invoke(set, raw_dir=raw_dir, processed_dir=processed_dir)
+        ctx.invoke(set_config, raw_dir=raw_dir, processed_dir=processed_dir)
 
 
-@config.command()
+@config.command(name="set")
 @click.option(
     "--raw-dir",
     help="Path for storing raw data.",
@@ -49,7 +49,7 @@ def config(ctx, raw_dir, processed_dir):
     type=click.Path(file_okay=False, dir_okay=True),
     required=False,
 )
-def set(raw_dir: Optional[Path], processed_dir: Optional[Path]):
+def set_config(raw_dir: Optional[Path], processed_dir: Optional[Path]):
     """Set raw and processed data directories."""
 
     # Get missing args from user prompts

--- a/brainsets/_cli/cli_config.py
+++ b/brainsets/_cli/cli_config.py
@@ -73,7 +73,7 @@ def set(raw_dir: Optional[Path], processed_dir: Optional[Path]):
     processed_dir.mkdir(parents=True, exist_ok=True)
 
     # Save config
-    cfg = load_config(raise_cli_error=False)
+    cfg = load_config()
     config_exists = cfg is not None
     if not config_exists:
         cfg = {}
@@ -93,7 +93,7 @@ def set(raw_dir: Optional[Path], processed_dir: Optional[Path]):
 @config.command()
 def show():
     """Display current configuration."""
-    cfg = load_config(raise_cli_error=False)
+    cfg = load_config()
     if cfg is None:
         raise click.ClickException(
             f"Config not found at {CONFIG_FILE}. Please run `brainsets config set`."

--- a/brainsets/_cli/cli_config.py
+++ b/brainsets/_cli/cli_config.py
@@ -5,10 +5,36 @@ from prompt_toolkit import prompt
 from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.completion import PathCompleter
 
-from .utils import load_config, save_config, expand_path
+from .utils import CONFIG_FILE, load_config, save_config, expand_path
 
 
-@click.command()
+@click.group(invoke_without_command=True)
+@click.option(
+    "--raw-dir",
+    help="[Deprecated] Path for storing raw data. Use `brainsets config set` instead.",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=False,
+)
+@click.option(
+    "--processed-dir",
+    help="[Deprecated] Path for storing processed brainsets. Use `brainsets config set` instead.",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=False,
+)
+@click.pass_context
+def config(ctx, raw_dir, processed_dir):
+    """Manage brainsets configuration."""
+    if ctx.invoked_subcommand is None:
+        # Deprecated: forward to `set` subcommand for backward compatibility
+        click.echo(
+            "Warning: `brainsets config [--raw-dir ... --processed-dir ...]` is "
+            "deprecated. Use `brainsets config set` instead.",
+            err=True,
+        )
+        ctx.invoke(set, raw_dir=raw_dir, processed_dir=processed_dir)
+
+
+@config.command()
 @click.option(
     "--raw-dir",
     help="Path for storing raw data.",
@@ -21,7 +47,7 @@ from .utils import load_config, save_config, expand_path
     type=click.Path(file_okay=False, dir_okay=True),
     required=False,
 )
-def config(raw_dir: Optional[Path], processed_dir: Optional[Path]):
+def set(raw_dir: Optional[Path], processed_dir: Optional[Path]):
     """Set raw and processed data directories."""
 
     # Get missing args from user prompts
@@ -45,18 +71,32 @@ def config(raw_dir: Optional[Path], processed_dir: Optional[Path]):
     processed_dir.mkdir(parents=True, exist_ok=True)
 
     # Save config
-    config = load_config(raise_cli_error=False)
-    config_exists = config is not None
+    cfg = load_config(raise_cli_error=False)
+    config_exists = cfg is not None
     if not config_exists:
-        config = {}
-    config["raw_dir"] = str(raw_dir)
-    config["processed_dir"] = str(processed_dir)
-    config_filepath = save_config(config)
+        cfg = {}
+    cfg["raw_dir"] = str(raw_dir)
+    cfg["processed_dir"] = str(processed_dir)
+    config_filepath = save_config(cfg)
 
     if not config_exists:
         click.echo(f"Created config file at {config_filepath}")
     else:
         click.echo(f"Updated config file at {config_filepath}")
 
-    click.echo(f"Raw data dir: {config['raw_dir']}")
-    click.echo(f"Processed data dir: {config['processed_dir']}")
+    click.echo(f"Raw data dir: {cfg['raw_dir']}")
+    click.echo(f"Processed data dir: {cfg['processed_dir']}")
+
+
+@config.command()
+def show():
+    """Display current configuration."""
+    cfg = load_config(raise_cli_error=False)
+    if cfg is None:
+        raise click.ClickException(
+            f"Config not found at {CONFIG_FILE}. Please run `brainsets config set`."
+        )
+
+    click.echo(f"Config file: {CONFIG_FILE}")
+    click.echo(f"Raw data dir: {cfg['raw_dir']}")
+    click.echo(f"Processed data dir: {cfg['processed_dir']}")

--- a/brainsets/_cli/cli_config.py
+++ b/brainsets/_cli/cli_config.py
@@ -5,7 +5,9 @@ from prompt_toolkit import prompt
 from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.completion import PathCompleter
 
-from .utils import CONFIG_FILE, load_config, save_config, expand_path
+from brainsets.config import CONFIG_FILE, load_config, save_config
+
+from .utils import expand_path
 
 
 @click.group(invoke_without_command=True)

--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -15,9 +15,10 @@ except ModuleNotFoundError:  # Python <3.11
 
 from click.shell_completion import CompletionItem
 
+from brainsets.config import CONFIG_FILE, load_config
+
 from .utils import (
     PIPELINES_PATH,
-    load_config,
     get_available_brainsets,
     expand_path,
 )
@@ -107,6 +108,11 @@ def prepare(
     # Get raw and processed dirs
     if raw_dir is None or processed_dir is None:
         config = load_config()
+        if config is None:
+            raise click.ClickException(
+                f"Config not found or invalid at {CONFIG_FILE}. "
+                "Please run `brainsets config set`."
+            )
         raw_dir = expand_path(raw_dir or config["raw_dir"])
         processed_dir = expand_path(processed_dir or config["processed_dir"])
     else:

--- a/brainsets/_cli/utils.py
+++ b/brainsets/_cli/utils.py
@@ -4,8 +4,6 @@ import click
 from pathlib import Path
 import brainsets_pipelines
 
-from brainsets.config import CONFIG_FILE, load_config as _load_config
-
 PIPELINES_PATH = Path(brainsets_pipelines.__path__[0])
 
 
@@ -14,17 +12,6 @@ def expand_path(path: Union[str, Path]) -> Path:
     Convert string path to absolute Path, expanding environment variables and user.
     """
     return Path(os.path.abspath(os.path.expandvars(os.path.expanduser(path))))
-
-
-def load_config(path: Path = CONFIG_FILE):
-    """Load config or raise a :class:`click.ClickException` on failure."""
-    config = _load_config(path)
-    if config is None:
-        raise click.ClickException(
-            f"Config not found or invalid at {path}. "
-            "Please run `brainsets config set`."
-        )
-    return config
 
 
 def get_available_brainsets():

--- a/brainsets/_cli/utils.py
+++ b/brainsets/_cli/utils.py
@@ -1,12 +1,11 @@
 import os
-from typing import Callable, List, Optional, Union
+from typing import Union
 import click
-import yaml
 from pathlib import Path
 import brainsets_pipelines
-from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
 
-CONFIG_FILE = Path.home() / ".brainsets.yaml"
+from brainsets.config import CONFIG_FILE, load_config as _load_config
+
 PIPELINES_PATH = Path(brainsets_pipelines.__path__[0])
 
 
@@ -17,43 +16,15 @@ def expand_path(path: Union[str, Path]) -> Path:
     return Path(os.path.abspath(os.path.expandvars(os.path.expanduser(path))))
 
 
-def load_config(path: Path = CONFIG_FILE, raise_cli_error: bool = True):
-    if path.exists():
-        with open(path, "r") as f:
-            ret = yaml.safe_load(f)
-
-        if raise_cli_error:
-            _validate_config(ret)
-        else:
-            try:
-                _validate_config(ret)
-            except:
-                return None
-
-        return ret
-    elif raise_cli_error:
+def load_config(path: Path = CONFIG_FILE):
+    """Load config or raise a :class:`click.ClickException` on failure."""
+    config = _load_config(path)
+    if config is None:
         raise click.ClickException(
-            f"Config not found at {path}. Please run `brainsets config`"
+            f"Config not found or invalid at {path}. "
+            "Please run `brainsets config set`."
         )
-    else:
-        return None
-
-
-def _validate_config(config: dict):
-    if "raw_dir" not in config:
-        raise click.ClickException(
-            "'raw_dir' missing in config. Please run `brainsets config`."
-        )
-    if "processed_dir" not in config:
-        raise click.ClickException(
-            "'processed_dir' missing in config. Please run `brainsets config`."
-        )
-
-
-def save_config(config):
-    with open(CONFIG_FILE, "w") as f:
-        yaml.safe_dump(config, f, default_flow_style=False)
-    return CONFIG_FILE
+    return config
 
 
 def get_available_brainsets():

--- a/brainsets/config.py
+++ b/brainsets/config.py
@@ -14,8 +14,11 @@ def load_config(path: Path = CONFIG_FILE) -> Optional[dict]:
     if not path.exists():
         return None
 
-    with open(path, "r") as f:
-        config = yaml.safe_load(f)
+    try:
+        with open(path, "r") as f:
+            config = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return None
 
     if not isinstance(config, dict):
         return None

--- a/brainsets/config.py
+++ b/brainsets/config.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+CONFIG_FILE = Path.home() / ".brainsets.yaml"
+
+
+def load_config(path: Path = CONFIG_FILE) -> Optional[dict]:
+    """Load and validate the brainsets config file.
+
+    Returns the config dict, or ``None`` if the file is missing or invalid.
+    """
+    if not path.exists():
+        return None
+
+    with open(path, "r") as f:
+        config = yaml.safe_load(f)
+
+    if not isinstance(config, dict):
+        return None
+    if "raw_dir" not in config or "processed_dir" not in config:
+        return None
+
+    return config
+
+
+def save_config(config: dict, path: Path = CONFIG_FILE) -> Path:
+    """Save the config dict to the brainsets config file."""
+    with open(path, "w") as f:
+        yaml.safe_dump(config, f, default_flow_style=False)
+    return path
+
+
+def get_processed_dir(path: Path = CONFIG_FILE) -> str:
+    """Return ``processed_dir`` from config, or raise if unavailable."""
+    config = load_config(path)
+    if config is None:
+        raise FileNotFoundError(
+            f"Config not found at {path}. "
+            "Please run `brainsets config set` or pass `root` explicitly."
+        )
+    return config["processed_dir"]

--- a/brainsets/config.py
+++ b/brainsets/config.py
@@ -33,14 +33,3 @@ def save_config(config: dict, path: Path = CONFIG_FILE) -> Path:
     with open(path, "w") as f:
         yaml.safe_dump(config, f, default_flow_style=False)
     return path
-
-
-def get_processed_dir(path: Path = CONFIG_FILE) -> str:
-    """Return ``processed_dir`` from config, or raise if unavailable."""
-    config = load_config(path)
-    if config is None:
-        raise FileNotFoundError(
-            f"Config not found at {path}. "
-            "Please run `brainsets config set` or pass `root` explicitly."
-        )
-    return config["processed_dir"]

--- a/brainsets/datasets/AllenVisualCodingOphys2016.py
+++ b/brainsets/datasets/AllenVisualCodingOphys2016.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, CalciumImagingDatasetMixin
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 
 class AllenVisualCodingOphys2016(CalciumImagingDatasetMixin, Dataset):

--- a/brainsets/datasets/AllenVisualCodingOphys2016.py
+++ b/brainsets/datasets/AllenVisualCodingOphys2016.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, CalciumImagingDatasetMixin
 
+from brainsets.config import get_processed_dir
+
 
 class AllenVisualCodingOphys2016(CalciumImagingDatasetMixin, Dataset):
     """
@@ -17,13 +19,15 @@ class AllenVisualCodingOphys2016(CalciumImagingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         split_type: Optional[Literal["poyo_plus"]] = "poyo_plus",
         dirname: str = "allen_visual_coding_ophys_2016",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
 
         super().__init__(
             dataset_dir=Path(root) / dirname,

--- a/brainsets/datasets/ChurchlandShenoyNeural2012.py
+++ b/brainsets/datasets/ChurchlandShenoyNeural2012.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 
 class ChurchlandShenoyNeural2012(SpikingDatasetMixin, Dataset):

--- a/brainsets/datasets/ChurchlandShenoyNeural2012.py
+++ b/brainsets/datasets/ChurchlandShenoyNeural2012.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
+from brainsets.config import get_processed_dir
+
 
 class ChurchlandShenoyNeural2012(SpikingDatasetMixin, Dataset):
     """
@@ -39,7 +41,7 @@ class ChurchlandShenoyNeural2012(SpikingDatasetMixin, Dataset):
     Version 0.251218.1714.
 
     Args:
-        root (str): Root directory for the dataset.
+        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
         recording_ids (list[str], optional): List of recording IDs to load.
         transform (Callable, optional): Data transformation to apply.
         split_type (str, optional): Which split type to use. Defaults to "cursor_velocity".
@@ -49,13 +51,15 @@ class ChurchlandShenoyNeural2012(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         split_type: Optional[Literal["cursor_velocity"]] = "cursor_velocity",
         dirname: str = "churchland_shenoy_neural_2012",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         super().__init__(
             dataset_dir=Path(root) / dirname,
             recording_ids=recording_ids,

--- a/brainsets/datasets/FlintSlutzkyAccurate2012.py
+++ b/brainsets/datasets/FlintSlutzkyAccurate2012.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 
 class FlintSlutzkyAccurate2012(SpikingDatasetMixin, Dataset):

--- a/brainsets/datasets/FlintSlutzkyAccurate2012.py
+++ b/brainsets/datasets/FlintSlutzkyAccurate2012.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
+from brainsets.config import get_processed_dir
+
 
 class FlintSlutzkyAccurate2012(SpikingDatasetMixin, Dataset):
     """
@@ -37,7 +39,7 @@ class FlintSlutzkyAccurate2012(SpikingDatasetMixin, Dataset):
     `Journal of Neural Engineering <https://doi.org/10.1088/1741-2560/9/4/046006>`_, 9(4), 046006.
 
     Args:
-        root (str): Root directory for the dataset.
+        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
         recording_ids (list[str], optional): List of recording IDs to load.
         transform (Callable, optional): Data transformation to apply.
         split_type (str, optional): Which split type to use. Defaults to "hand_velocity".
@@ -47,13 +49,15 @@ class FlintSlutzkyAccurate2012(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         split_type: Optional[Literal["hand_velocity"]] = "hand_velocity",
         dirname: str = "flint_slutzky_accurate_2012",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         super().__init__(
             dataset_dir=Path(root) / dirname,
             recording_ids=recording_ids,

--- a/brainsets/datasets/KempSleepEDF2013.py
+++ b/brainsets/datasets/KempSleepEDF2013.py
@@ -5,7 +5,7 @@ from temporaldata import Data
 
 from torch_brain.dataset import Dataset
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 FoldType = Literal["intrasession", "intersubject", "intersession"]
 VALID_FOLD_TYPES = get_args(FoldType)

--- a/brainsets/datasets/KempSleepEDF2013.py
+++ b/brainsets/datasets/KempSleepEDF2013.py
@@ -5,6 +5,8 @@ from temporaldata import Data
 
 from torch_brain.dataset import Dataset
 
+from brainsets.config import get_processed_dir
+
 FoldType = Literal["intrasession", "intersubject", "intersession"]
 VALID_FOLD_TYPES = get_args(FoldType)
 
@@ -18,7 +20,7 @@ class KempSleepEDF2013(Dataset):
         ``brainsets prepare kemp_sleep_edf_2013``.
 
     Args:
-        root (str): Root directory for the dataset.
+        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
         recording_ids (list[str], optional): List of recording IDs to load.
         transform (Callable, optional): Data transformation to apply.
         uniquify_channel_ids (bool, optional): Whether to prefix channel IDs with session ID to ensure uniqueness. Defaults to True.
@@ -33,7 +35,7 @@ class KempSleepEDF2013(Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         uniquify_channel_ids: bool = True,
@@ -42,6 +44,8 @@ class KempSleepEDF2013(Dataset):
         dirname: str = "kemp_sleep_edf_2013",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         super().__init__(
             dataset_dir=Path(root) / dirname,
             recording_ids=recording_ids,

--- a/brainsets/datasets/Neuroprobe2025.py
+++ b/brainsets/datasets/Neuroprobe2025.py
@@ -10,7 +10,7 @@ from temporaldata import Data, Interval
 
 from torch_brain.dataset import Dataset, MultiChannelDatasetMixin
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 SubsetTier = Literal["full", "lite", "nano"]
 LabelMode = Literal["binary", "multiclass"]

--- a/brainsets/datasets/Neuroprobe2025.py
+++ b/brainsets/datasets/Neuroprobe2025.py
@@ -10,6 +10,8 @@ from temporaldata import Data, Interval
 
 from torch_brain.dataset import Dataset, MultiChannelDatasetMixin
 
+from brainsets.config import get_processed_dir
+
 SubsetTier = Literal["full", "lite", "nano"]
 LabelMode = Literal["binary", "multiclass"]
 Regime = Literal["SS-SM", "SS-DM", "DS-DM"]
@@ -159,7 +161,7 @@ class Neuroprobe2025(MultiChannelDatasetMixin, Dataset):
     Data sources: `BrainTreeBank <https://braintreebank.dev>`_ and `Neuroprobe Benchmark <https://neuroprobe.dev>`_
 
     Args:
-        root: Root directory containing processed Neuroprobe artifacts.
+        root: Root directory containing processed Neuroprobe artifacts. Defaults to ``processed_dir`` from brainsets config.
         recording_ids: Optional explicit recording-id subset to expose from disk.
             If omitted, the dataset uses benchmark-required recording ids inferred
             from ``subset_tier/test_subject/test_session/split/label_mode/task/regime/fold``.
@@ -208,7 +210,7 @@ class Neuroprobe2025(MultiChannelDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         *,
@@ -225,6 +227,8 @@ class Neuroprobe2025(MultiChannelDatasetMixin, Dataset):
         dirname: str = "neuroprobe_2025",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         # Resolve and validate constructor inputs before touching dataset records.
         self._dataset_dir = Path(root) / dirname
 

--- a/brainsets/datasets/OdohertySabesNonhuman2017.py
+++ b/brainsets/datasets/OdohertySabesNonhuman2017.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 
 class OdohertySabesNonhuman2017(SpikingDatasetMixin, Dataset):

--- a/brainsets/datasets/OdohertySabesNonhuman2017.py
+++ b/brainsets/datasets/OdohertySabesNonhuman2017.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
+from brainsets.config import get_processed_dir
+
 
 class OdohertySabesNonhuman2017(SpikingDatasetMixin, Dataset):
     """
@@ -37,7 +39,7 @@ class OdohertySabesNonhuman2017(SpikingDatasetMixin, Dataset):
     `Zenodo Dataset <https://doi.org/10.5281/zenodo.788569>`_.
 
     Args:
-        root (str): Root directory for the dataset.
+        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
         recording_ids (list[str], optional): List of recording IDs to load.
         transform (Callable, optional): Data transformation to apply.
         split_type (str, optional): Which split type to use. Defaults to "cursor_velocity".
@@ -47,13 +49,15 @@ class OdohertySabesNonhuman2017(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         split_type: Optional[Literal["cursor_velocity"]] = "cursor_velocity",
         dirname: str = "odoherty_sabes_nonhuman_2017",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         super().__init__(
             dataset_dir=Path(root) / dirname,
             recording_ids=recording_ids,

--- a/brainsets/datasets/PeiPandarinathNLB2021.py
+++ b/brainsets/datasets/PeiPandarinathNLB2021.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
+from brainsets.config import get_processed_dir
+
 
 class PeiPandarinathNLB2021(SpikingDatasetMixin, Dataset):
     """
@@ -16,12 +18,14 @@ class PeiPandarinathNLB2021(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         dirname: str = "pei_pandarinath_nlb_2021",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         super().__init__(
             dataset_dir=Path(root) / dirname,
             recording_ids=recording_ids,

--- a/brainsets/datasets/PeiPandarinathNLB2021.py
+++ b/brainsets/datasets/PeiPandarinathNLB2021.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 
 class PeiPandarinathNLB2021(SpikingDatasetMixin, Dataset):

--- a/brainsets/datasets/PerichMillerPopulation2018.py
+++ b/brainsets/datasets/PerichMillerPopulation2018.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
+from brainsets.config import get_processed_dir
+
 
 class PerichMillerPopulation2018(SpikingDatasetMixin, Dataset):
     """
@@ -34,7 +36,7 @@ class PerichMillerPopulation2018(SpikingDatasetMixin, Dataset):
     Dataset: `Dandiset 000688 <https://doi.org/10.48324/dandi.000688/0.250122.1735>`_.
 
     Args:
-        root (str): Root directory for the dataset.
+        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
         recording_ids (list[str], optional): List of recording IDs to load.
         transform (Callable, optional): Data transformation to apply.
         dirname (str, optional): Subdirectory for the dataset. Defaults to "perich_miller_population_2018".
@@ -42,12 +44,14 @@ class PerichMillerPopulation2018(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str]] = None,
         transform: Optional[Callable] = None,
         dirname: str = "perich_miller_population_2018",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         super().__init__(
             dataset_dir=Path(root) / dirname,
             recording_ids=recording_ids,

--- a/brainsets/datasets/PerichMillerPopulation2018.py
+++ b/brainsets/datasets/PerichMillerPopulation2018.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
-from brainsets.config import get_processed_dir
+from ._utils import get_processed_dir
 
 
 class PerichMillerPopulation2018(SpikingDatasetMixin, Dataset):

--- a/brainsets/datasets/VollanMoserAlternating2025.py
+++ b/brainsets/datasets/VollanMoserAlternating2025.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from torch_brain.dataset import Dataset, SpikingDatasetMixin
 
+from ._utils import get_processed_dir
+
 
 class _RecordingGroup(list):
     """A list of recording IDs that also supports attribute access for sub-groups.
@@ -203,7 +205,7 @@ class VollanMoserAlternating2025(SpikingDatasetMixin, Dataset):
     Dataset: `EBRAINS <https://search.kg.ebrains.eu/instances/4080b78d-edc5-4ae4-8144-7f6de79930ea>`_.
 
     Args:
-        root (str): Root directory for the dataset.
+        root (str, optional): Root directory for the dataset. Defaults to ``processed_dir`` from brainsets config.
         recording_ids (list[str] or str, optional): Recording IDs to load.
             Defaults to all sessions.  Can be:
 
@@ -234,12 +236,14 @@ class VollanMoserAlternating2025(SpikingDatasetMixin, Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         recording_ids: Optional[list[str] or str] = None,
         transform: Optional[Callable] = None,
         dirname: str = "vollan_moser_alternating_2025",
         **kwargs,
     ):
+        if root is None:
+            root = get_processed_dir()
         if isinstance(recording_ids, str):
             if recording_ids not in self._SHORTHAND:
                 raise ValueError(

--- a/brainsets/datasets/_utils.py
+++ b/brainsets/datasets/_utils.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from brainsets.config import CONFIG_FILE, load_config
+
+
+def get_processed_dir(path: Path = CONFIG_FILE) -> str:
+    """Return ``processed_dir`` from config, or raise if unavailable."""
+    config = load_config(path)
+    if config is None:
+        raise FileNotFoundError(
+            f"Config not found at {path}. "
+            "Please run `brainsets config set` or pass `root` explicitly."
+        )
+    return config["processed_dir"]

--- a/docs/source/concepts/using_existing_data.rst
+++ b/docs/source/concepts/using_existing_data.rst
@@ -7,15 +7,19 @@ Configuring data directories
 ----------------------------
 First, configure the directories where brainsets will store raw and processed data::
 
-    brainsets config
+    brainsets config set
 
 You will be prompted to enter the paths to the raw and processed data directories::
 
-    $> brainsets config
+    $> brainsets config set
     Enter raw data directory: ./data/raw
     Enter processed data directory: ./data/processed
 
-You can update the configuration at any time by running the ``config`` command again.
+You can update the configuration at any time by running the ``config set`` command again.
+
+To view the current configuration::
+
+    brainsets config show
 
 Listing available datasets
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "msgpack>=1.0.5",
     "pydantic>=2.0",
     "click>=8.1.3",
+    "pyyaml>=6.0",
     "uv",
     "prompt_toolkit",
     "numpy>=1.14.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from brainsets._cli.cli_completion import (
     _detect_shell,
     SHELL_COMPLETION_FILENAMES,
 )
-from brainsets._cli.utils import CONFIG_FILE
+from brainsets.config import CONFIG_FILE
 
 
 class TestDetectShell:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,9 +100,7 @@ class TestConfigCommand:
         processed_dir = str(tmp_path / "processed")
         mock_config = {"raw_dir": raw_dir, "processed_dir": processed_dir}
 
-        with patch(
-            "brainsets._cli.cli_config.load_config", return_value=mock_config
-        ):
+        with patch("brainsets._cli.cli_config.load_config", return_value=mock_config):
             result = runner.invoke(cli, ["config", "show"])
             assert result.exit_code == 0, f"CLI failed with: {result.output}"
             assert f"Config file: {CONFIG_FILE}" in result.output
@@ -124,9 +122,10 @@ class TestConfigCommand:
         raw_dir = tmp_path / "raw"
         processed_dir = tmp_path / "processed"
 
-        with patch(
-            "brainsets._cli.cli_config.load_config", return_value=None
-        ), patch("brainsets._cli.cli_config.save_config", return_value=CONFIG_FILE):
+        with (
+            patch("brainsets._cli.cli_config.load_config", return_value=None),
+            patch("brainsets._cli.cli_config.save_config", return_value=CONFIG_FILE),
+        ):
             result = runner.invoke(
                 cli,
                 [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from brainsets._cli.cli_completion import (
     _detect_shell,
     SHELL_COMPLETION_FILENAMES,
 )
+from brainsets._cli.utils import CONFIG_FILE
 
 
 class TestDetectShell:
@@ -87,6 +88,59 @@ class TestInstallCompletion:
         assert result.exit_code == 0
         assert comp_dir.exists()
         assert (comp_dir / SHELL_COMPLETION_FILENAMES["bash"]).is_file()
+
+
+class TestConfigCommand:
+    """Tests for the 'brainsets config' command group."""
+
+    def test_config_show(self, tmp_path):
+        """Test `brainsets config show` displays current configuration."""
+        runner = CliRunner()
+        raw_dir = str(tmp_path / "raw")
+        processed_dir = str(tmp_path / "processed")
+        mock_config = {"raw_dir": raw_dir, "processed_dir": processed_dir}
+
+        with patch(
+            "brainsets._cli.cli_config.load_config", return_value=mock_config
+        ):
+            result = runner.invoke(cli, ["config", "show"])
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+            assert f"Config file: {CONFIG_FILE}" in result.output
+            assert f"Raw data dir: {raw_dir}" in result.output
+            assert f"Processed data dir: {processed_dir}" in result.output
+
+    def test_config_show_no_config(self):
+        """Test `brainsets config show` errors when no config exists."""
+        runner = CliRunner()
+
+        with patch("brainsets._cli.cli_config.load_config", return_value=None):
+            result = runner.invoke(cli, ["config", "show"])
+            assert result.exit_code != 0
+            assert "Config not found" in result.output
+
+    def test_config_set_with_options(self, tmp_path):
+        """Test `brainsets config set --raw-dir ... --processed-dir ...`."""
+        runner = CliRunner()
+        raw_dir = tmp_path / "raw"
+        processed_dir = tmp_path / "processed"
+
+        with patch(
+            "brainsets._cli.cli_config.load_config", return_value=None
+        ), patch("brainsets._cli.cli_config.save_config", return_value=CONFIG_FILE):
+            result = runner.invoke(
+                cli,
+                [
+                    "config",
+                    "set",
+                    "--raw-dir",
+                    str(raw_dir),
+                    "--processed-dir",
+                    str(processed_dir),
+                ],
+            )
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+            assert f"Raw data dir: {raw_dir}" in result.output
+            assert f"Processed data dir: {processed_dir}" in result.output
 
 
 class TestPrepareCommand:


### PR DESCRIPTION
Currently there's no way to view the brainsets config from the CLI, and dataset classes require an explicit `root` path even though `brainsets prepare` already writes data to a known `processed_dir`. Since we sometimes want to point to different raw and processed directories (e.g. temporarily for a specific project), having a quick way to check what's currently configured is useful. And having datasets default to the configured `processed_dir` means you can just write `PeiPandarinathNLB2021()` after running `brainsets prepare`.

This converts `brainsets config` into a command group with `config set` (previous behavior) and `config show` (new). The old `brainsets config --raw-dir ... --processed-dir ...` form still works with a deprecation warning. Config reading/writing has been extracted into a top-level `brainsets.config` module so dataset classes can access it without pulling in CLI dependencies. All 8 dataset classes now default `root=None` and fall back to the config. CI workflows, README, and docs have been updated, and tests have been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added config subcommands: "set" to save data-directory settings and "show" to display current configuration. Using the old flags now emits a deprecation warning.
  * Dataset loaders now default to the configured processed-data directory when no root is provided; prepare will error with guidance if no config exists.

* **Documentation**
  * Updated CLI examples and guides to reflect the new config commands.

* **Tests**
  * Added tests covering config show/set behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->