### PR TITLE
Bug fix: churchland_shenoy_neural_2012 task name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Exposed `--download-only` flag in `brainsets prepare --help` to allow downloading raw data without processing ([#98](https://github.com/neuro-galaxy/brainsets/pull/98)).
 - Updated dandi version to 0.74.0 in pipelines due to deprecation from dandi ([#101](https://github.com/neuro-galaxy/brainsets/pull/101)).
 - `BrainsetPipeline` runner automatically creates `raw_dir` and `processed_dir` ([#125](https://github.com/neuro-galaxy/brainsets/pull/125))
+- `churchland_shenoy_neural_2012` pipeline: corrected session task metadata—the experiment is maze reaching, not center-out reaching (`derived_version` bumped to 2.0.0). ([#131](https://github.com/neuro-galaxy/brainsets/pull/131))
 
 ## [0.2.0] - 2025-12-24
 ### Added

--- a/brainsets_pipelines/churchland_shenoy_neural_2012/pipeline.py
+++ b/brainsets_pipelines/churchland_shenoy_neural_2012/pipeline.py
@@ -78,7 +78,7 @@ class Pipeline(BrainsetPipeline):
         brainset_description = BrainsetDescription(
             id="churchland_shenoy_neural_2012",
             origin_version="dandi/000070/draft",
-            derived_version="1.0.0",
+            derived_version="2.0.0",
             source="https://dandiarchive.org/dandiset/000070",
             description="Monkeys recordings of Motor Cortex (M1) and dorsal Premotor Cortex"
             " (PMd) using two 96 channel high density Utah Arrays (Blackrock Microsystems) "

--- a/brainsets_pipelines/churchland_shenoy_neural_2012/pipeline.py
+++ b/brainsets_pipelines/churchland_shenoy_neural_2012/pipeline.py
@@ -95,7 +95,7 @@ class Pipeline(BrainsetPipeline):
         recording_date = nwbfile.session_start_time.strftime("%Y%m%d")
         subject_id = subject.id
         device_id = f"{subject_id}_{recording_date}"
-        session_id = f"{device_id}_center_out_reaching"
+        session_id = f"{device_id}_maze"
 
         store_path = self.processed_dir / f"{session_id}.h5"
         if store_path.exists() and not self.args.reprocess:
@@ -207,8 +207,8 @@ def extract_trials(nwbfile, session_id):
     if len(artifact_index) > 0:
         # logging.info(f"Found {len(artifact_index)} artifacts in the trial table.")
         if session_id in [
-            "nitschke_20090910_center_out_reaching",
-            "nitschke_20090920_center_out_reaching",
+            "nitschke_20090910_maze",
+            "nitschke_20090920_maze",
         ]:
             # the first artifact corresponds to two overlapping trials
             # we will skip those two trials


### PR DESCRIPTION
The dataset consists of maze reaching behavior, but was mislabeled as center out reaching. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Corrected task metadata for a neural data pipeline: sessions previously labeled as "center-out reaching" are now identified as "maze" tasks.
  * Adjusted session naming and output file identifiers to match the maze-based format, improving consistency of stored session files and trial extraction.
  * Bumped pipeline derived version to 2.0.0 and documented the change in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->