### PR TITLE
feat(cli): make `--list` and `-s`/`--single` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added shell completion for brainsets CLI tools ([#116](https://github.com/neuro-galaxy/brainsets/pull/116)).
 - Added the `Neuroprobe2025` dataset class and the `neuroprobe_2025` brainset pipeline ([#79](https://github.com/neuro-galaxy/brainsets/pull/79)).
 - Added new brainset `vollan_moser_alternating_2025`, a hippocampus/MEC dataset from the paper [Left–right-alternating theta sweeps in entorhinal–hippocampal maps of space](https://www.nature.com/articles/s41586-024-08527-1). See [#127](https://github.com/neuro-galaxy/brainsets/pull/127).
+- Add `--list`, `-s`/`--single` to `brainsets prepare` ([#137](https://github.com/neuro-galaxy/brainsets/pull/137)).
 
 ### Removed
 - Remove `brainsets.utils.dir_utils` (legacy code) ([#120](https://github.com/neuro-galaxy/brainsets/pull/120)).

--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -60,6 +60,19 @@ def complete_brainset(ctx, param, incomplete):
     ),
 )
 @click.option(
+    "--list",
+    is_flag=True,
+    default=False,
+    help="Print the manifest for the brainset and exit.",
+)
+@click.option(
+    "--single",
+    "-s",
+    type=str,
+    default="",
+    help="Prepare a single item from the manifest if provided. Value: manifest index id for the item.",
+)
+@click.option(
     "--use-active-env",
     is_flag=True,
     default=False,
@@ -88,6 +101,8 @@ def prepare(
     cores: int,
     verbose: bool,
     download_only: bool,
+    list: bool,
+    single: str,
     use_active_env: bool,
     raw_dir: Optional[str],
     processed_dir: Optional[str],
@@ -153,6 +168,8 @@ def prepare(
         f"--processed-dir={processed_dir}",
         f"-c{cores}",
         *(["--download-only"] if download_only else []),
+        *(["--list"] if list else []),
+        *([f"--single={single}"] if single else []),
         *ctx.args,  # extra arguments
     ]
 

--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -51,15 +51,6 @@ def complete_brainset(ctx, param, incomplete):
     help="Path for storing processed brainset. Overrides config.",
 )
 @click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help=(
-        "Prepare brainset with from a local pipeline. "
-        "BRAINSET must then be set to the path of the local brainset pipeline directory."
-    ),
-)
-@click.option(
     "--list",
     is_flag=True,
     default=False,
@@ -71,6 +62,15 @@ def complete_brainset(ctx, param, incomplete):
     type=str,
     default="",
     help="Prepare a single item from the manifest if provided. Value: manifest index id for the item.",
+)
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help=(
+        "Prepare brainset with from a local pipeline. "
+        "BRAINSET must then be set to the path of the local brainset pipeline directory."
+    ),
 )
 @click.option(
     "--use-active-env",

--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -118,6 +118,8 @@ def prepare(
     $ brainsets prepare pei_pandarinath_nlb_2021
     $ brainsets prepare pei_pandarinath_nlb_2021 --download-only
     $ brainsets prepare pei_pandarinath_nlb_2021 --cores 8 --raw-dir ~/data/raw --processed-dir ~/data/processed
+    $ brainsets prepare pei_pandarinath_nlb_2021 --list
+    $ brainsets prepare pei_pandarinath_nlb_2021 --single jenkins_maze_train
     $ brainsets prepare ./my_local_brainsets_pipeline --local
     """
 

--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -52,6 +52,7 @@ def complete_brainset(ctx, param, incomplete):
 )
 @click.option(
     "--list",
+    "list_flag_",
     is_flag=True,
     default=False,
     help="Print the manifest for the brainset and exit.",
@@ -101,7 +102,7 @@ def prepare(
     cores: int,
     verbose: bool,
     download_only: bool,
-    list: bool,
+    list_flag_: bool,
     single: str,
     use_active_env: bool,
     raw_dir: Optional[str],
@@ -168,7 +169,7 @@ def prepare(
         f"--processed-dir={processed_dir}",
         f"-c{cores}",
         *(["--download-only"] if download_only else []),
-        *(["--list"] if list else []),
+        *(["--list"] if list_flag_ else []),
         *([f"--single={single}"] if single else []),
         *ctx.args,  # extra arguments
     ]

--- a/brainsets/_cli/cli_prepare.py
+++ b/brainsets/_cli/cli_prepare.py
@@ -61,7 +61,7 @@ def complete_brainset(ctx, param, incomplete):
     "--single",
     "-s",
     type=str,
-    default="",
+    default=None,
     help="Prepare a single item from the manifest if provided. Value: manifest index id for the item.",
 )
 @click.option(
@@ -170,7 +170,7 @@ def prepare(
         f"-c{cores}",
         *(["--download-only"] if download_only else []),
         *(["--list"] if list_flag_ else []),
-        *([f"--single={single}"] if single else []),
+        *([f"--single={single}"] if single is not None else []),
         *ctx.args,  # extra arguments
     ]
 

--- a/docs/source/cli/commands.rst
+++ b/docs/source/cli/commands.rst
@@ -138,6 +138,18 @@ Download and process a single brainset.
 
 .. rst-class:: cli-option
 
+``--list``
+
+    Print the manifest for the brainset and exit.
+
+.. rst-class:: cli-option
+
+``-s``, ``--single`` *manifest index string*
+
+    Prepare a single item from the manifest if provided.
+
+.. rst-class:: cli-option
+
 ``--local``
 
     Prepare a brainset from a local pipeline directory instead of the built-in registry.

--- a/docs/source/cli/commands.rst
+++ b/docs/source/cli/commands.rst
@@ -144,7 +144,7 @@ Download and process a single brainset.
 
 .. rst-class:: cli-option
 
-``-s``, ``--single`` *manifest index string*
+``-s``, ``--single`` *manifest index id*
 
     Prepare a single item from the manifest if provided.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,11 +289,11 @@ class TestPrepareCommand:
             assert "--list" not in command
 
     def test_single_option(self, mock_config):
-        """Test prepare command with --list flag
+        """Test prepare command with -s/--single option
         Ensure it is forwarded to the runner subprocess."""
         runner = CliRunner()
 
-        # --single=test passed if present in cli args
+        # --single=test passed if "--single test" present in cli args
         with (
             patch("brainsets._cli.cli_prepare.load_config", return_value=mock_config),
             patch("brainsets._cli.cli_prepare.subprocess.run") as mock_subprocess,
@@ -301,6 +301,23 @@ class TestPrepareCommand:
             mock_subprocess.return_value = MagicMock(returncode=0)
             result = runner.invoke(
                 cli, ["prepare", "pei_pandarinath_nlb_2021", "--single", "test-index"]
+            )
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+
+            mock_subprocess.assert_called_once()
+            call_args = mock_subprocess.call_args
+            command = call_args[1].get("command") or call_args[0][0]
+
+            assert "--single=test-index" in command
+
+        # --single=test passed if "-s test" test present in cli args
+        with (
+            patch("brainsets._cli.cli_prepare.load_config", return_value=mock_config),
+            patch("brainsets._cli.cli_prepare.subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0)
+            result = runner.invoke(
+                cli, ["prepare", "pei_pandarinath_nlb_2021", "-s", "test-index"]
             )
             assert result.exit_code == 0, f"CLI failed with: {result.output}"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,6 +308,9 @@ class TestPrepareCommand:
             command = call_args[1].get("command") or call_args[0][0]
 
             assert "--single=test-index" in command
+            for part in command:
+                assert part != "-s"
+                assert not part.startswith("-s=")
 
         # --single=test passed if "-s test" test present in cli args
         with (
@@ -325,6 +328,9 @@ class TestPrepareCommand:
             command = call_args[1].get("command") or call_args[0][0]
 
             assert "--single=test-index" in command
+            for part in command:
+                assert part != "-s"
+                assert not part.startswith("-s=")
 
         # --single not passed if absent in cli args
         with (
@@ -341,7 +347,7 @@ class TestPrepareCommand:
 
             for part in command:
                 assert part != "--single"
-                assert part != "--s"
+                assert part != "-s"
                 assert not part.startswith("--single=")
                 assert not part.startswith("-s=")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,6 +251,84 @@ class TestPrepareCommand:
 
             assert "--download-only" in command
 
+    def test_list_flag(self, mock_config):
+        """Test prepare command with --list flag
+        Ensure it is forwarded to the runner subprocess."""
+        runner = CliRunner()
+
+        # --list passed if present in cli args
+        with (
+            patch("brainsets._cli.cli_prepare.load_config", return_value=mock_config),
+            patch("brainsets._cli.cli_prepare.subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0)
+            result = runner.invoke(
+                cli, ["prepare", "pei_pandarinath_nlb_2021", "--list"]
+            )
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+
+            mock_subprocess.assert_called_once()
+            call_args = mock_subprocess.call_args
+            command = call_args[1].get("command") or call_args[0][0]
+
+            assert "--list" in command
+
+        # --list not passed if absent in cli args
+        with (
+            patch("brainsets._cli.cli_prepare.load_config", return_value=mock_config),
+            patch("brainsets._cli.cli_prepare.subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0)
+            result = runner.invoke(cli, ["prepare", "pei_pandarinath_nlb_2021"])
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+
+            mock_subprocess.assert_called_once()
+            call_args = mock_subprocess.call_args
+            command = call_args[1].get("command") or call_args[0][0]
+
+            assert "--list" not in command
+
+    def test_single_option(self, mock_config):
+        """Test prepare command with --list flag
+        Ensure it is forwarded to the runner subprocess."""
+        runner = CliRunner()
+
+        # --single=test passed if present in cli args
+        with (
+            patch("brainsets._cli.cli_prepare.load_config", return_value=mock_config),
+            patch("brainsets._cli.cli_prepare.subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0)
+            result = runner.invoke(
+                cli, ["prepare", "pei_pandarinath_nlb_2021", "--single", "test-index"]
+            )
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+
+            mock_subprocess.assert_called_once()
+            call_args = mock_subprocess.call_args
+            command = call_args[1].get("command") or call_args[0][0]
+
+            assert "--single=test-index" in command
+
+        # --single not passed if absent in cli args
+        with (
+            patch("brainsets._cli.cli_prepare.load_config", return_value=mock_config),
+            patch("brainsets._cli.cli_prepare.subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0)
+            result = runner.invoke(cli, ["prepare", "pei_pandarinath_nlb_2021"])
+            assert result.exit_code == 0, f"CLI failed with: {result.output}"
+
+            mock_subprocess.assert_called_once()
+            call_args = mock_subprocess.call_args
+            command = call_args[1].get("command") or call_args[0][0]
+
+            for part in command:
+                assert part != "--single"
+                assert part != "--s"
+                assert not part.startswith("--single=")
+                assert not part.startswith("-s=")
+
     def test_extra_option_passthrough(self, mock_config):
         """Test that extra options are passed through to the subprocess."""
         runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,8 +289,7 @@ class TestPrepareCommand:
             assert "--list" not in command
 
     def test_single_option(self, mock_config):
-        """Test prepare command with -s/--single option
-        Ensure it is forwarded to the runner subprocess."""
+        """Test passthrough of the --single/-s option to the runner subprocess."""
         runner = CliRunner()
 
         # --single=test passed if "--single test" present in cli args


### PR DESCRIPTION
Simple change. `--list` and `-s`/`--single` have proven to be useful CLI features for the `brainsets prepare` command, especially for development and debugging phase. These were not "public", in the sense that they were not exposed by the `brainsets prepare` command, and hence would not show up in `brainsets prepare --help`. 

This PR 
- Exposes both options/flags from `brainsets prepare`. 
- It also adds them to the CLI reference doc page.