### PR TITLE
feat: regularize NLB Maze's behavior signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `churchland_shenoy_neural_2012` pipeline: corrected session task metadata—the experiment is maze reaching, not center-out reaching (`derived_version` bumped to 2.0.0). ([#131](https://github.com/neuro-galaxy/brainsets/pull/131))
 - Replaced deprecated `data.set_*_domain()` calls with direct attribute assignment in all pipelines ([#111](https://github.com/neuro-galaxy/brainsets/issues/109)).
 - `odoherty_sabes_nonhuman_2017` pipeline: uses RegularTimeSeries for storing behavioral data (`derived_version` bumped to 2.0.0). ([#138](https://github.com/neuro-galaxy/brainsets/pull/138))
+- `pei_pandarinath_nlb_2021` pipeline: regularize behavior signals; insert NaNs into missing timesteps (`derived_version` bumped to 2.0.0) ([#140](https://github.com/neuro-galaxy/brainsets/pull/140))
 
 
 ## [0.2.0] - 2025-12-24

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/README.md
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/README.md
@@ -1,0 +1,4 @@
+### Changelog
+
+#### `derived_version 2.0.0`
+Regularize the behavior timeseries' by inserting NaNs into missing points

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/README.md
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/README.md
@@ -1,4 +1,4 @@
 ### Changelog
 
 #### `derived_version 2.0.0`
-Regularize the behavior timeseries' by inserting NaNs into missing points
+Regularize the behavior time series by inserting NaNs into missing points

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -217,6 +217,8 @@ def extract_behavior(nwbfile, trials):
     start_time, end_time = raw_timestamps[0], raw_timestamps[-1]
     num_timesteps = round((end_time - start_time) * samp_rate) + 1
     raw_time_idx = np.round((raw_timestamps - start_time) * samp_rate).astype(int)
+    assert (np.diff(raw_time_idx) > 0).all()
+    # ^ this confirms there are no repeated timesteps
     assert np.isclose(raw_time_idx / samp_rate, raw_timestamps - start_time).all()
     # ^ this confirms that the raw_timestamps are indeed regular relative to start_time
 

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -6,9 +6,10 @@
 from argparse import ArgumentParser
 import datetime
 
+import numpy as np
 import h5py
 from pynwb import NWBHDF5IO
-from temporaldata import Data, IrregularTimeSeries, Interval
+from temporaldata import Data, IrregularTimeSeries, Interval, RegularTimeSeries
 import pandas as pd
 
 from brainsets.descriptions import (
@@ -24,6 +25,7 @@ from brainsets.utils.dandi_utils import (
 )
 from brainsets.taxonomy import RecordingTech, Task
 from brainsets import serialize_fn_map
+from brainsets.utils.misc_utils import calculate_sampling_rate
 
 from brainsets.pipeline import BrainsetPipeline
 
@@ -66,7 +68,7 @@ class Pipeline(BrainsetPipeline):
         brainset_description = BrainsetDescription(
             id=self.brainset_id,
             origin_version="dandi/000140/0.220113.0408",
-            derived_version="1.0.0",
+            derived_version="2.0.0",
             source="https://dandiarchive.org/dandiset/000140",
             description="This dataset contains sorted unit spiking times and behavioral"
             " data from a macaque performing a delayed reaching task. The experimental task"
@@ -203,22 +205,40 @@ def extract_behavior(nwbfile, trials):
         depending on the sequence. # todo investigate more
     """
     # cursor, hand and eye share the same timestamps (verified)
-    timestamps = nwbfile.processing["behavior"]["hand_vel"].timestamps[:]
-    hand_pos = nwbfile.processing["behavior"]["hand_pos"].data[:]
-    hand_vel = nwbfile.processing["behavior"]["hand_vel"].data[:]
-    eye_pos = nwbfile.processing["behavior"]["eye_pos"].data[:]
+    raw_timestamps = nwbfile.processing["behavior"]["hand_vel"].timestamps[:]
+    raw_hand_pos = nwbfile.processing["behavior"]["hand_pos"].data[:]
+    raw_hand_vel = nwbfile.processing["behavior"]["hand_vel"].data[:]
+    raw_eye_pos = nwbfile.processing["behavior"]["eye_pos"].data[:]
 
-    hand = IrregularTimeSeries(
-        timestamps=timestamps,
+    # These samples are mostly uniformly sampled at 1000Hz,
+    # but have some missing points. Here we insert NaNs at
+    # the missing timesteps to regularize the timeseries
+    samp_rate = 1e3
+    start_time, end_time = raw_timestamps[0], raw_timestamps[-1]
+    num_timesteps = round((end_time - start_time) * samp_rate) + 1
+    time_idx = np.round((raw_timestamps - start_time) * samp_rate).astype(int)
+
+    hand_pos = np.full((num_timesteps, raw_hand_pos.shape[-1]), fill_value=np.nan)
+    hand_vel = np.full((num_timesteps, raw_hand_vel.shape[-1]), fill_value=np.nan)
+    eye_pos = np.full((num_timesteps, raw_eye_pos.shape[-1]), fill_value=np.nan)
+
+    hand_pos[time_idx] = raw_hand_pos
+    hand_vel[time_idx] = raw_hand_vel
+    eye_pos[time_idx] = raw_eye_pos
+
+    hand = RegularTimeSeries(
+        sampling_rate=samp_rate,
         pos=hand_pos,
         vel=hand_vel,
         domain="auto",
+        domain_start=start_time,
     )
 
-    eye = IrregularTimeSeries(
-        timestamps=timestamps,
+    eye = RegularTimeSeries(
+        sampling_rate=samp_rate,
         pos=eye_pos,
         domain="auto",
+        domain_start=start_time,
     )
 
     return hand, eye

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -25,7 +25,6 @@ from brainsets.utils.dandi_utils import (
 )
 from brainsets.taxonomy import RecordingTech, Task
 from brainsets import serialize_fn_map
-from brainsets.utils.misc_utils import calculate_sampling_rate
 
 from brainsets.pipeline import BrainsetPipeline
 
@@ -218,7 +217,7 @@ def extract_behavior(nwbfile, trials):
     num_timesteps = round((end_time - start_time) * samp_rate) + 1
     raw_time_idx = np.round((raw_timestamps - start_time) * samp_rate).astype(int)
     assert (np.diff(raw_time_idx) > 0).all()
-    # ^ this confirms there are no repeated timesteps
+    # ^ this confirms there are no repeated timestamps
     assert np.isclose(raw_time_idx / samp_rate, raw_timestamps - start_time).all()
     # ^ this confirms that the raw_timestamps are indeed regular relative to start_time
 

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -216,15 +216,18 @@ def extract_behavior(nwbfile, trials):
     samp_rate = 1e3
     start_time, end_time = raw_timestamps[0], raw_timestamps[-1]
     num_timesteps = round((end_time - start_time) * samp_rate) + 1
-    time_idx = np.round((raw_timestamps - start_time) * samp_rate).astype(int)
+    raw_time_idx = np.round((raw_timestamps - start_time) * samp_rate).astype(int)
+    assert np.isclose(raw_time_idx / samp_rate, raw_timestamps).all()
+    # ^ this confirms that the raw_timestamps are indeed regular
 
     hand_pos = np.full((num_timesteps, raw_hand_pos.shape[-1]), fill_value=np.nan)
-    hand_vel = np.full((num_timesteps, raw_hand_vel.shape[-1]), fill_value=np.nan)
-    eye_pos = np.full((num_timesteps, raw_eye_pos.shape[-1]), fill_value=np.nan)
+    hand_pos[raw_time_idx] = raw_hand_pos
 
-    hand_pos[time_idx] = raw_hand_pos
-    hand_vel[time_idx] = raw_hand_vel
-    eye_pos[time_idx] = raw_eye_pos
+    hand_vel = np.full((num_timesteps, raw_hand_vel.shape[-1]), fill_value=np.nan)
+    hand_vel[raw_time_idx] = raw_hand_vel
+
+    eye_pos = np.full((num_timesteps, raw_eye_pos.shape[-1]), fill_value=np.nan)
+    eye_pos[raw_time_idx] = raw_eye_pos
 
     hand = RegularTimeSeries(
         sampling_rate=samp_rate,

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -217,8 +217,8 @@ def extract_behavior(nwbfile, trials):
     start_time, end_time = raw_timestamps[0], raw_timestamps[-1]
     num_timesteps = round((end_time - start_time) * samp_rate) + 1
     raw_time_idx = np.round((raw_timestamps - start_time) * samp_rate).astype(int)
-    assert np.isclose(raw_time_idx / samp_rate, raw_timestamps).all()
-    # ^ this confirms that the raw_timestamps are indeed regular
+    assert np.isclose(raw_time_idx / samp_rate, raw_timestamps - start_time).all()
+    # ^ this confirms that the raw_timestamps are indeed regular relative to start_time
 
     hand_pos = np.full((num_timesteps, raw_hand_pos.shape[-1]), fill_value=np.nan)
     hand_pos[raw_time_idx] = raw_hand_pos


### PR DESCRIPTION
**Problem:** The behavior timeseries' in NLB maze are _almost regular_ except that they are missing some timesteps. Due to this, we have been using IrregularTimeSeries for them. But IrregularTS is quite bad for behavior signals due to numerical precision errors in sampling.

**Fix:** This PR converts the behavior signals into pure RegularTimeSeries. This is done by inserting `NaN`s in the signal values for the missing timesteps.