### PR TITLE
feat: Add utility function `fill_gappy_timeseries`

### DIFF
--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -60,7 +60,7 @@ def fill_missing_timesteps(
     sampling_rate: float,
     gap_value: float = np.nan,
     rtol: float = 1e-3,
-) -> tuple[np.ndarray, np.ndarray | list[np.ndarray]]:
+) -> np.ndarray | list[np.ndarray]:
     """Fill gaps in a regular-but-gappy time series.
 
     Maps an almost-regularly-sampled signal onto a regular grid at
@@ -80,11 +80,7 @@ def fill_missing_timesteps(
             grid. Defaults to 1e-3.
 
     Returns:
-        Tuple ``(timestamps, values)``. Both have first
-        dimension spanning ``timestamps[0]`` to ``timestamps[-1]`` at
-        ``sampling_rate``, with ``gap_value`` at missing entries.
-        The returned ``values`` is a single array if the input
-        ``values`` was an array, otherwise a list of arrays.
+        The gap-filled ``values``.
 
     Raises:
         ValueError: If ``timestamps`` is not 1D, has fewer than 2 entries,
@@ -156,6 +152,4 @@ def fill_missing_timesteps(
             " or a list of numpy arrays."
         )
 
-    clean_timestamps = fill_gaps(timestamps)
-
-    return clean_timestamps, clean_values
+    return clean_values

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -56,7 +56,7 @@ def calculate_sampling_rate(timestamps: np.ndarray, rtol: float = 1e-3) -> float
 
 def fill_gappy_timeseries(
     timestamps: np.ndarray,
-    values: np.ndarray | Iterable[np.ndarray],
+    values: np.ndarray | list[np.ndarray] | tuple[np.ndarray, ...],
     sampling_rate: float,
     gap_value: float = np.nan,
     rtol: float = 1e-3,

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -58,7 +58,7 @@ def calculate_sampling_rate(timestamps: np.ndarray, rtol: float = 1e-3) -> float
 def fill_gappy_timeseries(
     timestamps: np.ndarray,
     values: np.ndarray | Iterable[np.ndarray],
-    sampling_rate: float | None = None,
+    sampling_rate: float,
     gap_value: float = np.nan,
     rtol: float = 1e-3,
 ) -> tuple[np.ndarray, np.ndarray | list[np.ndarray]]:
@@ -93,14 +93,6 @@ def fill_gappy_timeseries(
 
     if not (np.diff(timestamps) > 0).all():
         raise ValueError("Input timestamps are not monotonic")
-
-    if sampling_rate is None:
-        # use mode time difference
-        # numpy does not have a direct mode() function
-        diffs = np.diff(timestamps)
-        uniq_diffs, counts = np.unique(diffs, return_counts=True)
-        mode_diff = uniq_diffs[np.argmax(counts)]
-        sampling_rate = 1.0 / mode_diff
 
     start_time, end_time = timestamps[0], timestamps[-1]
     rel_ts = timestamps - start_time

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -1,9 +1,11 @@
 _functions = [
     "calculate_sampling_rate",
+    "fill_gappy_timeseries",
 ]
 
 __all__ = _functions
 
+from typing import Iterable
 import numpy as np
 
 
@@ -51,3 +53,103 @@ def calculate_sampling_rate(timestamps: np.ndarray, rtol: float = 1e-3) -> float
         )
 
     return 1.0 / dt
+
+
+def fill_gappy_timeseries(
+    timestamps: np.ndarray,
+    values: np.ndarray | Iterable[np.ndarray],
+    sampling_rate: float | None = None,
+    gap_value: float = np.nan,
+    rtol: float = 1e-3,
+) -> tuple[np.ndarray, np.ndarray | list[np.ndarray]]:
+    """Fill gaps in an regular-but-gappy time series
+
+    Fills the gaps in 'almost regular' time series which has gaps in
+    the sampling times.
+
+    Args:
+        timestamps: Array of sampling timestamps; shape :math:`(T,)`
+        value: Either a single array of values with shape :math:`(T, ...)`,
+            or a list of arrays with the first dimension having the same size
+            as timestamps.
+        sampling_rate: The sampling rate of the time series. If None,
+            sampling rate is calculated as the median time difference.
+            (default :obj:`None`)
+        gap_value: Value to fill in the gaps (default :obj:`np.nan`)
+
+    Returns:
+        timestamps, values
+    """
+
+    if timestamps.ndim != 1:
+        raise ValueError(
+            f"Timestamps must be a 1D array, got {timestamps.ndim}D array with shape {timestamps.shape}"
+        )
+
+    if len(timestamps) < 2:
+        raise ValueError(
+            f"This function needs at least 2 timestamps, got {timestamps.size}"
+        )
+
+    if not (np.diff(timestamps) > 0).all():
+        raise ValueError("Input timestamps are not monotonic")
+
+    if sampling_rate is None:
+        # use mode time difference
+        # numpy does not have a direct mode() function
+        diffs = np.diff(timestamps)
+        uniq_diffs, counts = np.unique(diffs, return_counts=True)
+        mode_diff = uniq_diffs[np.argmax(counts)]
+        sampling_rate = 1.0 / mode_diff
+
+    start_time, end_time = timestamps[0], timestamps[-1]
+    rel_ts = timestamps - start_time
+    clean_time_idx = np.round(rel_ts * sampling_rate).astype(int)
+
+    # Check for rtol
+    relative_variation = clean_time_idx - (rel_ts * sampling_rate)
+    max_relative_varation = np.max(np.abs(relative_variation))
+    if max_relative_varation > rtol:
+        raise ValueError(
+            "Timestamps are not uniformly sampled "
+            f"(max relative variation={max_relative_varation:.2e} >= rtol={rtol}). "
+            f"Perhaps {sampling_rate=} is not a good sampling rate, or "
+            f"this timeseries is inherently irregular."
+        )
+
+    num_timesteps = round((end_time - start_time) * sampling_rate) + 1
+
+    def fill_gaps(values):
+        if values.ndim > 1:
+            shape = (num_timesteps, *values.shape[1:])
+        else:
+            shape = (num_timesteps,)
+
+        ans = np.full(shape, fill_value=gap_value)
+        ans[clean_time_idx] = values
+        return ans
+
+    clean_timestamps = fill_gaps(timestamps)
+
+    if isinstance(values, np.ndarray):
+        if len(values) != len(timestamps):
+            raise ValueError(f"Shape mismatch: {len(timestamps)=} != {len(values)=}")
+        clean_values = fill_gaps(values)
+
+    elif isinstance(values, (list, tuple)):
+        clean_values = []
+        for i, v in enumerate(values):
+            if len(v) != len(timestamps):
+                raise ValueError(
+                    f"Shape mismatch on {i}th values: {len(timestamps)=} != {len(values)=}"
+                )
+            clean_values.append(fill_gaps(v))
+
+    else:
+        raise ValueError(
+            f"Incorrect type of `values`: {type(values)}."
+            " This function accepts a single numpy array,"
+            " or a list of numpy arrays."
+        )
+
+    return clean_timestamps, clean_values

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -81,7 +81,7 @@ def fill_gappy_timeseries(
             grid. Defaults to 1e-3.
 
     Returns:
-        Tuple ``(clean_timestamps, clean_values)``. Both have first
+        Tuple ``(timestamps, values)``. Both have first
         dimension spanning ``timestamps[0]`` to ``timestamps[-1]`` at
         ``sampling_rate``, with ``gap_value`` at missing entries.
         ``clean_values`` is a single array if ``values`` was an array,

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -135,8 +135,6 @@ def fill_missing_timesteps(
         ans[clean_time_idx] = arr
         return ans
 
-    clean_timestamps = fill_gaps(timestamps)
-
     if isinstance(values, np.ndarray):
         if len(values) != len(timestamps):
             raise ValueError(f"Shape mismatch: {len(timestamps)=} != {len(values)=}")
@@ -157,5 +155,7 @@ def fill_missing_timesteps(
             " This function accepts a single numpy array,"
             " or a list of numpy arrays."
         )
+
+    clean_timestamps = fill_gaps(timestamps)
 
     return clean_timestamps, clean_values

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -148,7 +148,7 @@ def fill_gappy_timeseries(
         for i, v in enumerate(values):
             if len(v) != len(timestamps):
                 raise ValueError(
-                    f"Shape mismatch on {i}th values: {len(timestamps)=} != {len(values)=}"
+                    f"Shape mismatch on {i}th values: {len(timestamps)=} != {len(v)=}"
                 )
             clean_values.append(fill_gaps(v))
 

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -83,8 +83,8 @@ def fill_missing_timesteps(
         Tuple ``(timestamps, values)``. Both have first
         dimension spanning ``timestamps[0]`` to ``timestamps[-1]`` at
         ``sampling_rate``, with ``gap_value`` at missing entries.
-        ``clean_values`` is a single array if ``values`` was an array,
-        otherwise a list of arrays.
+        The returned ``values`` is a single array if the input
+        ``values`` was an array, otherwise a list of arrays.
 
     Raises:
         ValueError: If ``timestamps`` is not 1D, has fewer than 2 entries,
@@ -125,14 +125,14 @@ def fill_missing_timesteps(
 
     num_timesteps = round((end_time - start_time) * sampling_rate) + 1
 
-    def fill_gaps(values):
-        if values.ndim > 1:
-            shape = (num_timesteps, *values.shape[1:])
+    def fill_gaps(arr):
+        if arr.ndim > 1:
+            shape = (num_timesteps, *arr.shape[1:])
         else:
             shape = (num_timesteps,)
 
         ans = np.full(shape, fill_value=gap_value)
-        ans[clean_time_idx] = values
+        ans[clean_time_idx] = arr
         return ans
 
     clean_timestamps = fill_gaps(timestamps)

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -1,6 +1,6 @@
 _functions = [
     "calculate_sampling_rate",
-    "fill_gappy_timeseries",
+    "fill_missing_timesteps",
 ]
 
 __all__ = _functions

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -54,7 +54,7 @@ def calculate_sampling_rate(timestamps: np.ndarray, rtol: float = 1e-3) -> float
     return 1.0 / dt
 
 
-def fill_gappy_timeseries(
+def fill_missing_timesteps(
     timestamps: np.ndarray,
     values: np.ndarray | list[np.ndarray] | tuple[np.ndarray, ...],
     sampling_rate: float,

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -62,23 +62,38 @@ def fill_gappy_timeseries(
     gap_value: float = np.nan,
     rtol: float = 1e-3,
 ) -> tuple[np.ndarray, np.ndarray | list[np.ndarray]]:
-    """Fill gaps in an regular-but-gappy time series
+    """Fill gaps in a regular-but-gappy time series.
 
-    Fills the gaps in 'almost regular' time series which has gaps in
-    the sampling times.
+    Maps an almost-regularly-sampled signal onto a regular grid at
+    ``sampling_rate``, inserting ``gap_value`` at every missing timestep
+    so the result can be stored as a RegularTimeSeries.
 
     Args:
-        timestamps: Array of sampling timestamps; shape :math:`(T,)`
-        value: Either a single array of values with shape :math:`(T, ...)`,
-            or a list of arrays with the first dimension having the same size
-            as timestamps.
-        sampling_rate: The sampling rate of the time series. If None,
-            sampling rate is calculated as the median time difference.
-            (default :obj:`None`)
-        gap_value: Value to fill in the gaps (default :obj:`np.nan`)
+        timestamps: 1D array of sampling timestamps in seconds; shape
+            :math:`(T,)`. Must be strictly monotonically increasing.
+        values: Either a single array with first dimension :math:`T`, or a
+            list/tuple of such arrays.
+        sampling_rate: Sampling rate of the underlying regular signal in Hz.
+        gap_value: Value inserted at missing timesteps. Defaults to
+            :obj:`np.nan`.
+        rtol: Maximum allowed offset, in fractions of a sample, between
+            each input timestamp and the nearest point on the regular
+            grid. Defaults to 1e-3.
 
     Returns:
-        timestamps, values
+        Tuple ``(clean_timestamps, clean_values)``. Both have first
+        dimension spanning ``timestamps[0]`` to ``timestamps[-1]`` at
+        ``sampling_rate``, with ``gap_value`` at missing entries.
+        ``clean_values`` is a single array if ``values`` was an array,
+        otherwise a list of arrays.
+
+    Raises:
+        ValueError: If ``timestamps`` is not 1D, has fewer than 2 entries,
+            or is not strictly monotonically increasing.
+        ValueError: If the timestamps do not align with the regular grid
+            at ``sampling_rate`` within ``rtol``.
+        ValueError: If any element of ``values`` has a first dimension
+            that does not match ``timestamps``.
     """
 
     if timestamps.ndim != 1:

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -119,6 +119,18 @@ def fill_missing_timesteps(
             f"this timeseries is inherently irregular."
         )
 
+    # Catch the case where sampling_rate is an integer multiple of the true
+    # rate: every timestamp lands on a grid point (so the rtol check passes),
+    # but the smallest gap between consecutive samples is > 1 grid step.
+    min_idx_gap = int(np.min(np.diff(clean_time_idx)))
+    if min_idx_gap > 1:
+        raise ValueError(
+            f"{sampling_rate=} appears too high: smallest gap between "
+            f"consecutive samples on the regular grid is {min_idx_gap} steps "
+            f"(expected 1). The true sampling rate may be closer to "
+            f"{sampling_rate / min_idx_gap}."
+        )
+
     num_timesteps = round((end_time - start_time) * sampling_rate) + 1
 
     def fill_gaps(arr):

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -115,11 +115,11 @@ def fill_gappy_timeseries(
 
     # Check for rtol
     relative_variation = clean_time_idx - (rel_ts * sampling_rate)
-    max_relative_varation = np.max(np.abs(relative_variation))
-    if max_relative_varation > rtol:
+    max_relative_variation = np.max(np.abs(relative_variation))
+    if max_relative_variation > rtol:
         raise ValueError(
             "Timestamps are not uniformly sampled "
-            f"(max relative variation={max_relative_varation:.2e} >= rtol={rtol}). "
+            f"(max relative variation={max_relative_variation:.2e} >= rtol={rtol}). "
             f"Perhaps {sampling_rate=} is not a good sampling rate, or "
             f"this timeseries is inherently irregular."
         )

--- a/brainsets/utils/misc_utils.py
+++ b/brainsets/utils/misc_utils.py
@@ -5,7 +5,6 @@ _functions = [
 
 __all__ = _functions
 
-from typing import Iterable
 import numpy as np
 
 

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -27,7 +27,7 @@ from brainsets.taxonomy import RecordingTech, Task
 from brainsets import serialize_fn_map
 
 from brainsets.pipeline import BrainsetPipeline
-from brainsets.utils.misc_utils import fill_gappy_timeseries
+from brainsets.utils.misc_utils import fill_missing_timesteps
 
 parser = ArgumentParser()
 parser.add_argument("--redownload", action="store_true")
@@ -211,7 +211,7 @@ def extract_behavior(nwbfile, trials):
     raw_eye_pos = nwbfile.processing["behavior"]["eye_pos"].data[:]
 
     samp_rate = 1e3
-    timestamps, (hand_pos, hand_vel, eye_pos) = fill_gappy_timeseries(
+    timestamps, (hand_pos, hand_vel, eye_pos) = fill_missing_timesteps(
         timestamps=raw_timestamps,
         values=(raw_hand_pos, raw_hand_vel, raw_eye_pos),
         sampling_rate=samp_rate,

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -211,7 +211,7 @@ def extract_behavior(nwbfile, trials):
     raw_eye_pos = nwbfile.processing["behavior"]["eye_pos"].data[:]
 
     samp_rate = 1e3
-    timestamps, (hand_pos, hand_vel, eye_pos) = fill_missing_timesteps(
+    hand_pos, hand_vel, eye_pos = fill_missing_timesteps(
         timestamps=raw_timestamps,
         values=(raw_hand_pos, raw_hand_vel, raw_eye_pos),
         sampling_rate=samp_rate,
@@ -222,14 +222,14 @@ def extract_behavior(nwbfile, trials):
         pos=hand_pos,
         vel=hand_vel,
         domain="auto",
-        domain_start=timestamps[0],
+        domain_start=raw_timestamps[0],
     )
 
     eye = RegularTimeSeries(
         sampling_rate=samp_rate,
         pos=eye_pos,
         domain="auto",
-        domain_start=timestamps[0],
+        domain_start=raw_timestamps[0],
     )
 
     return hand, eye

--- a/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
+++ b/brainsets_pipelines/pei_pandarinath_nlb_2021/pipeline.py
@@ -27,6 +27,7 @@ from brainsets.taxonomy import RecordingTech, Task
 from brainsets import serialize_fn_map
 
 from brainsets.pipeline import BrainsetPipeline
+from brainsets.utils.misc_utils import fill_gappy_timeseries
 
 parser = ArgumentParser()
 parser.add_argument("--redownload", action="store_true")
@@ -209,40 +210,26 @@ def extract_behavior(nwbfile, trials):
     raw_hand_vel = nwbfile.processing["behavior"]["hand_vel"].data[:]
     raw_eye_pos = nwbfile.processing["behavior"]["eye_pos"].data[:]
 
-    # These samples are mostly uniformly sampled at 1000Hz,
-    # but have some missing points. Here we insert NaNs at
-    # the missing timesteps to regularize the timeseries
     samp_rate = 1e3
-    start_time, end_time = raw_timestamps[0], raw_timestamps[-1]
-    num_timesteps = round((end_time - start_time) * samp_rate) + 1
-    raw_time_idx = np.round((raw_timestamps - start_time) * samp_rate).astype(int)
-    assert (np.diff(raw_time_idx) > 0).all()
-    # ^ this confirms there are no repeated timestamps
-    assert np.isclose(raw_time_idx / samp_rate, raw_timestamps - start_time).all()
-    # ^ this confirms that the raw_timestamps are indeed regular relative to start_time
-
-    hand_pos = np.full((num_timesteps, raw_hand_pos.shape[-1]), fill_value=np.nan)
-    hand_pos[raw_time_idx] = raw_hand_pos
-
-    hand_vel = np.full((num_timesteps, raw_hand_vel.shape[-1]), fill_value=np.nan)
-    hand_vel[raw_time_idx] = raw_hand_vel
-
-    eye_pos = np.full((num_timesteps, raw_eye_pos.shape[-1]), fill_value=np.nan)
-    eye_pos[raw_time_idx] = raw_eye_pos
+    timestamps, (hand_pos, hand_vel, eye_pos) = fill_gappy_timeseries(
+        timestamps=raw_timestamps,
+        values=(raw_hand_pos, raw_hand_vel, raw_eye_pos),
+        sampling_rate=samp_rate,
+    )
 
     hand = RegularTimeSeries(
         sampling_rate=samp_rate,
         pos=hand_pos,
         vel=hand_vel,
         domain="auto",
-        domain_start=start_time,
+        domain_start=timestamps[0],
     )
 
     eye = RegularTimeSeries(
         sampling_rate=samp_rate,
         pos=eye_pos,
         domain="auto",
-        domain_start=start_time,
+        domain_start=timestamps[0],
     )
 
     return hand, eye

--- a/brainsets_pipelines/perich_miller_population_2018/pipeline.py
+++ b/brainsets_pipelines/perich_miller_population_2018/pipeline.py
@@ -19,7 +19,7 @@ from scipy.ndimage import binary_dilation, binary_erosion
 from sklearn.model_selection import train_test_split
 import pandas as pd
 
-from temporaldata import Data, IrregularTimeSeries, Interval
+from temporaldata import Data, IrregularTimeSeries, Interval, RegularTimeSeries
 from brainsets.descriptions import (
     BrainsetDescription,
     SessionDescription,
@@ -35,6 +35,7 @@ from brainsets.taxonomy import RecordingTech, Task
 from brainsets import serialize_fn_map
 
 from brainsets.pipeline import BrainsetPipeline
+from brainsets.utils.misc_utils import fill_missing_timesteps
 
 parser = ArgumentParser()
 parser.add_argument("--redownload", action="store_true")
@@ -225,12 +226,20 @@ def extract_behavior(nwbfile):
     cursor_vel = nwbfile.processing["behavior"]["Velocity"]["cursor_vel"].data[:]
     cursor_acc = nwbfile.processing["behavior"]["Acceleration"]["cursor_acc"].data[:]
 
-    cursor = IrregularTimeSeries(
+    samp_rate = 100.0
+    cursor_pos, cursor_vel, cursor_acc = fill_missing_timesteps(
         timestamps=timestamps,
+        values=(cursor_pos, cursor_vel, cursor_acc),
+        sampling_rate=samp_rate,
+    )
+
+    cursor = RegularTimeSeries(
+        sampling_rate=samp_rate,
         pos=cursor_pos,
         vel=cursor_vel,
         acc=cursor_acc,
         domain="auto",
+        domain_start=timestamps[0],
     )
 
     return cursor


### PR DESCRIPTION
This PR stems from #140.

**Problem:** Many times behavior signals are inherently regular timeseries signals, but have missing values. We have been generally handling them as irregular timeseries. But that is ot great due to numerical precision errors when slicing (sometimes your slice gets 99 points instead of 100). 

**FIx:** Converting to regular timeseries would be great. And one way to do so would be to insert `NaN`s wherever the timestaps are missing. This PR provides a utility to do that.