### PR TITLE
release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+
+### Removed
+
+### Changed
+
+### Fixed
+
+## [0.2.2] - 2026-05-31
+### Added
 - Added the `OpenNeuroDataset` and the `OpenNeuroPipeline` base classes ([#128](https://github.com/neuro-galaxy/brainsets/pull/128)).
 
 ### Removed
@@ -13,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed the `type` attribute from channel/unit ArrayDicts in pipelines; use `DeviceDescription` to store recording technology instead. Affects `churchland_shenoy_neural_2012`, `neuroprobe_2025`, `odoherty_sabes_nonhuman_2017`, `pei_pandarinath_nlb_2021`, and `perich_miller_population_2018` ([#146](https://github.com/neuro-galaxy/brainsets/pull/146)).
 
 ### Changed
+- Upgraded `temporaldata` version to `>= 0.1.6` ([#154](https://github.com/neuro-galaxy/brainsets/pull/154)).
 - Simplified `brainsets.descriptions`: the description classes (`BrainsetDescription`, `SubjectDescription`, `SessionDescription`, `DeviceDescription`) are now plain `temporaldata.Data` subclasses with explicit validation that accept arbitrary `**kwargs`, dropping the dependency on `pydantic` and the `brainsets.taxonomy` enums. Non-general attributes (e.g. `cre_line`) are no longer first-class fields but can be passed via `**kwargs`, and attributes that may be "unknown" (e.g. `species`, `sex`) now default to `None` ([#146](https://github.com/neuro-galaxy/brainsets/pull/146)).
 - An unknown `recording_date` is now represented as `None` instead of the Unix epoch (`1970-01-01`), affecting MNE-based datasets and `vollan_moser_alternating_2025` ([#146](https://github.com/neuro-galaxy/brainsets/pull/146)).
 

--- a/brainsets/utils/mne_utils.py
+++ b/brainsets/utils/mne_utils.py
@@ -300,10 +300,6 @@ def extract_signal(
     return RegularTimeSeries(
         signal=signal,
         sampling_rate=sfreq,
-        domain=Interval(
-            start=np.array([0.0]),
-            end=np.array([(len(signal) - 1) / sfreq]),
-        ),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "temporaldata",
+    "temporaldata>=0.1.6",
     "scipy>=1.10.1",
     "pynwb>=2.2.0",
     "pandas>=1.5.3",
@@ -39,7 +39,7 @@ dev = [
     "flake8",
     "pytest-cov",
     "scikit-learn>=1.6.1",
-    "torch_brain@git+https://github.com/neuro-galaxy/torch_brain",
+    "torch_brain==0.1.2",
     "mne~=1.11.0",
     "boto3~=1.41.0",
     "mne-bids",

--- a/tests/test_mne_utils.py
+++ b/tests/test_mne_utils.py
@@ -121,12 +121,12 @@ class TestExtractSignal:
         assert result.domain.start[0] == 0.0
 
     def test_domain_end_calculation(self):
-        """Test that domain end is calculated as (n_samples - 1) / sfreq."""
+        """Test that domain end is calculated as n_samples / sfreq."""
         n_samples = 1000
         sfreq = 256.0
         mock_raw = create_mock_raw(n_samples=n_samples, sfreq=sfreq)
         result = extract_signal(mock_raw)
-        expected_end = (n_samples - 1) / sfreq
+        expected_end = n_samples / sfreq
         assert np.isclose(result.domain.end[0], expected_end)
 
     def test_raises_error_when_no_samples(self):


### PR DESCRIPTION
- Updated versions of temporaldata and torch_brain (hardcoded `torch_brain==0.1.2`)
- Fixed test failures due to breaking changes in temporaldata
- Changelog
